### PR TITLE
docs: create api specification file

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -39,7 +39,7 @@ endpoints:
         - email
         - fullname
         - title
-        - status
+        - state
         - access
     post:
       enabled: true

--- a/docs/specification.yaml
+++ b/docs/specification.yaml
@@ -468,6 +468,76 @@ paths:
               examples:
                 NotFound:
                   $ref: '#/components/examples/NotFoundResponse'
+  /plugins:
+    get:
+      tags:
+        - plugins
+      summary: Get all the plugins installed on the site
+      security:
+        - basic: ['admin.api', 'admin.super']
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PluginResponse'
+                  meta:
+                    $ref: '#/components/schemas/ResponseMetadata'
+        401:
+          description: Invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                InvalidAuth:
+                  $ref: '#/components/examples/InvalidAuthResponse'
+  /plugins/{id}:
+    get:
+      tags:
+        - plugins
+      summary: Get a specific plugin
+      security:
+        - basic: ['admin.api', 'admin.super']
+      parameters:
+        - name: id
+          in: path
+          description: The id of the plugin to return
+          required: true
+          schema:
+            type: string
+            example: "joe"
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PluginResponse'
+        401:
+          description: Invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                InvalidAuth:
+                  $ref: '#/components/examples/InvalidAuthResponse'
+        404:
+          description: Plugin not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                NotFound:
+                  $ref: '#/components/examples/NotFoundResponse'
 components:
   securitySchemes:
     basic:
@@ -602,6 +672,43 @@ components:
               type: string
               description: A link to this resource through the API
               example: "https://www.mysite.com/api/pages/blog/my-first-post"
+    PluginHypermedia:
+      type: object
+      properties:
+        related:
+          type: object
+          properties:
+            self:
+              type: string
+              description: A link to this resource through the API
+              example: "https://www.mysite.com/api/plugins/api"
+    PluginResponse:
+      type: object
+      properties:
+        type:
+          type: string
+          description: The resource type
+          example: "plugin"
+        id:
+          type: string
+          description: The ID of the plugin
+          example: "api"
+        attributes:
+          $ref: '#/components/schemas/PluginResource'
+        links:
+          $ref: '#/components/schemas/PluginHypermedia'
+    PluginResource:
+      type: object
+      description: The plugin's configuration options. The returned fields vary depending on the plugin.
+      properties:
+        enabled:
+          type: boolean
+          description: Whether or not the plugin is active
+          example: true
+        custom_field:
+          type: string
+          description: Each plugin might have different custom fields
+          example: "An example plugin custom field"
     ResponseMetadata:
       type: object
       properties:

--- a/docs/specification.yaml
+++ b/docs/specification.yaml
@@ -12,8 +12,8 @@ info:
 tags:
   - name: pages
   - name: users
-  - name: config
   - name: plugins
+  - name: configs
 paths:
   /pages:
     get:
@@ -512,7 +512,7 @@ paths:
           required: true
           schema:
             type: string
-            example: "joe"
+            example: "api"
       responses:
         200:
           description: Successful operation
@@ -538,12 +538,115 @@ paths:
               examples:
                 NotFound:
                   $ref: '#/components/examples/NotFoundResponse'
+  /configs:
+    get:
+      tags:
+        - configs
+      summary: Get all the site configuration files
+      security:
+        - basic: ['admin.api', 'admin.super']
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/ConfigResponse'
+                  meta:
+                    $ref: '#/components/schemas/ResponseMetadata'
+        401:
+          description: Invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                InvalidAuth:
+                  $ref: '#/components/examples/InvalidAuthResponse'
+  /configs/{id}:
+    get:
+      tags:
+        - configs
+      summary: Get a specific config file
+      security:
+        - basic: ['admin.api', 'admin.super']
+      parameters:
+        - name: id
+          in: path
+          description: The id of the config file to return
+          required: true
+          schema:
+            type: string
+            example: "site"
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ConfigResponse'
+        401:
+          description: Invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                InvalidAuth:
+                  $ref: '#/components/examples/InvalidAuthResponse'
+        404:
+          description: Configuration file not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                NotFound:
+                  $ref: '#/components/examples/NotFoundResponse'
 components:
   securitySchemes:
     basic:
       type: http
       scheme: Basic
   schemas:
+    ConfigHypermedia:
+      type: object
+      properties:
+        related:
+          type: object
+          properties:
+            self:
+              type: string
+              description: A link to this resource through the API
+              example: "https://www.mysite.com/api/config/site"
+    ConfigResponse:
+      type: object
+      properties:
+        type:
+          type: string
+          description: The resource type
+          example: "config"
+        id:
+          type: string
+          description: The ID of the config
+          example: "api"
+        attributes:
+          $ref: '#/components/schemas/ConfigResource'
+        links:
+          $ref: '#/components/schemas/ConfigHypermedia'
+    ConfigResource:
+      type: object
+      description: The configuration file's properties. The returned fields vary depending on the configuration file.
+      properties:
+        some_field:
+          type: string
+          description: Each config file will have different fields
+          example: "An example config field"
     ErrorResponse:
       type: object
       properties:

--- a/docs/specification.yaml
+++ b/docs/specification.yaml
@@ -11,8 +11,8 @@ info:
     url: https://github.com/Regaez/grav-plugin-api/blob/master/LICENSE
 tags:
   - name: pages
-  - name: config
   - name: users
+  - name: config
   - name: plugins
 paths:
   /pages:
@@ -33,7 +33,7 @@ paths:
                     items:
                       $ref: '#/components/schemas/PageResponse'
                   meta:
-                    $ref: '#/components/schemas/PagesMetadata'
+                    $ref: '#/components/schemas/ResponseMetadata'
         401:
           description: Invalid authentication
           content:
@@ -233,8 +233,258 @@ paths:
               examples:
                 NotFound:
                   $ref: '#/components/examples/NotFoundResponse'
+  /users:
+    get:
+      tags:
+        - users
+      summary: Get all the users on the site
+      security:
+        - basic: ['admin.api', 'admin.super']
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/UserResponse'
+                  meta:
+                    $ref: '#/components/schemas/ResponseMetadata'
+        401:
+          description: Invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                InvalidAuth:
+                  $ref: '#/components/examples/InvalidAuthResponse'
+    post:
+      tags:
+        - users
+      summary: Add a new user
+      security:
+        - basic: ['admin.api', 'admin.super']
+      description: >-
+        There are a minimum of three required fields you must provide for the POST request to be successful. These are: `username`, `password` and `email`. If any of these are not specified, then the user will not be created. They are all expected as plain strings. Additionally, the `email` field must be a **valid email format**.
+
+
+        There are further optional fields you may specify: `fullname`, `title`, `state`, and `access`.
+
+
+        The `fullname` should be a plain string. If no `fullname` is provided, then the user will simply be a fullname which is a [titleized](https://learn.getgrav.org/themes/twig-filters-functions#titleize) version of their username.
+
+
+        The `title` field should be a plain string. If no `title` is provided, then the user will simply be given the title: "User".
+
+
+        The `state` field should be a string, either `'enabled'` or `'disabled'`. If this field is not provided, then the user will be `enabled` by default.
+
+
+        The `access` field should be a JSON structure, matching a set of access roles on the site.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserRequestBody'
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        400:
+          description: Bad request. You must provide a `username`, `password` and a valid `email` field.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                BadRequest:
+                  $ref: '#/components/examples/BadRequestResponse'
+        401:
+          description: Invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                InvalidAuth:
+                  $ref: '#/components/examples/InvalidAuthResponse'
+        403:
+          description: Forbidden. This user already exists.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                Forbidden:
+                  $ref: '#/components/examples/ForbiddenResponse'
+  /users/{id}:
+    get:
+      tags:
+        - users
+      summary: Get a specific user
+      security:
+        - basic: ['admin.api', 'admin.super']
+      parameters:
+        - name: id
+          in: path
+          description: The username of the user to return
+          required: true
+          schema:
+            type: string
+            example: "joe"
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        401:
+          description: Invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                InvalidAuth:
+                  $ref: '#/components/examples/InvalidAuthResponse'
+        404:
+          description: Page not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                NotFound:
+                  $ref: '#/components/examples/NotFoundResponse'
+    patch:
+      tags:
+        - users
+      summary: Update a specific user
+      security:
+        - basic: ['admin.api', 'admin.super']
+      description: >-
+        In order to change user information, you **must** provide a valid `password` for that user.
+
+
+        Similarly to a `POST` request, you can also submit the following fields: `email`, `title`, `fullname`, and `new_password`.
+
+
+        Additionally, if you authenticate as an `admin`, you may also change the `access` rights for the user.
+
+
+        Existing `access` information will not changed, unless the corresponding key is explicitly set. In order to remove an existing role, you must set the field's value to `null`.
+      parameters:
+        - name: id
+          in: path
+          description: The username of the user to update
+          required: true
+          schema:
+            type: string
+            example: "joe"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserUpdateRequestBody'
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserResponse'
+        400:
+          description: Bad request. You must provide a `password` field.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                BadRequest:
+                  $ref: '#/components/examples/BadRequestResponse'
+        401:
+          description: Invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                InvalidAuth:
+                  $ref: '#/components/examples/InvalidAuthResponse'
+        404:
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                NotFound:
+                  $ref: '#/components/examples/NotFoundResponse'
+    delete:
+      tags:
+        - users
+      summary: Delete a specific user
+      security:
+        - basic: ['admin.api', 'admin.super']
+      description: >-
+        If the deletion is successful, the API will respond with a `204` no-content status code.
+
+        > **WARNING:** THIS WILL PERMANENTLY DELETE A USER. IT CANNOT BE UNDONE. It is recommended to instead `PATCH` a user and set `"state": "disabled"` for the user, if you do not want the user active any longer.
+      parameters:
+        - name: id
+          in: path
+          description: The username of the user to delete
+          required: true
+          schema:
+            type: string
+            example: "joe"
+      responses:
+        204:
+          description: Successful operation
+        401:
+          description: Invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                InvalidAuth:
+                  $ref: '#/components/examples/InvalidAuthResponse'
+        404:
+          description: Page not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                NotFound:
+                  $ref: '#/components/examples/NotFoundResponse'
 components:
+  securitySchemes:
+    basic:
+      type: http
+      scheme: Basic
   schemas:
+    ErrorResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          description: A short message describing the error
+          example: "Resource not found"
+        documentation:
+          type: string
+          description: A URL to the documentation for reference
+          example: "https://github.com/regaez/grav-plugin-api/tree/master/docs"
     PageResponse:
       type: object
       properties:
@@ -309,29 +559,6 @@ components:
           type: number
           description: The date/time of when the post was last modified, as UNIX timestamp
           example: 1564936730
-    PageHypermedia:
-      type: object
-      properties:
-        self:
-          type: string
-          description: A link to this resource on the site
-          example: "https://www.mysite.com/blog/my-first-post"
-        related:
-          type: object
-          properties:
-            self:
-              type: string
-              description: A link to this resource through the API
-              example: "https://www.mysite.com/api/pages/blog/my-first-post"
-    PagesMetadata:
-      type: object
-      properties:
-        count:
-          type: number
-          description: The number of pages returned by the request
-          example: 2
-      required:
-        - count
     PageRequestBody:
       type: object
       properties:
@@ -361,17 +588,199 @@ components:
           example: "This is a _new_ page's content in **markdown**!"
       required:
         - route
-    ErrorResponse:
+    PageHypermedia:
       type: object
       properties:
-        message:
+        self:
           type: string
-          description: A short message describing the error
-          example: "Resource not found"
-        documentation:
+          description: A link to this resource on the site
+          example: "https://www.mysite.com/blog/my-first-post"
+        related:
+          type: object
+          properties:
+            self:
+              type: string
+              description: A link to this resource through the API
+              example: "https://www.mysite.com/api/pages/blog/my-first-post"
+    ResponseMetadata:
+      type: object
+      properties:
+        count:
+          type: number
+          description: The number of pages returned by the request
+          example: 2
+      required:
+        - count
+    UserHypermedia:
+      type: object
+      properties:
+        related:
+          type: object
+          properties:
+            self:
+              type: string
+              description: A link to this resource through the API
+              example: "https://www.mysite.com/api/users/joe"
+    UserResponse:
+      type: object
+      properties:
+        type:
           type: string
-          description: A URL to the documentation for reference
-          example: "https://github.com/regaez/grav-plugin-api/tree/master/docs"
+          description: The resource type
+          example: "user"
+        id:
+          type: string
+          description: The ID of the user (this is also the username)
+          example: "admin"
+        attributes:
+          $ref: '#/components/schemas/UserResource'
+        links:
+          $ref: '#/components/schemas/UserHypermedia'
+    UserResource:
+      type: object
+      properties:
+        username:
+          type: string
+          description: The username
+          example: "admin"
+        email:
+          type: string
+          description: The user's registered email address
+          example: "admin@mysite.com"
+        fullname:
+          type: string
+          description: The user's fullname
+          example: "Joe Bloggs"
+        title:
+          type: string
+          description: The user's title
+          example: "Administrator"
+        access:
+          type: object
+          description: The user's access roles
+          properties:
+            admin:
+              type: object
+              properties:
+                login:
+                  type: boolean
+                  example: true
+                super:
+                  type: boolean
+                  example: true
+            site:
+              type: object
+              properties:
+                login:
+                  type: boolean
+                  example: true
+    UserRequestBody:
+      type: object
+      properties:
+        username:
+          type: string
+          description: The new user's username
+          example: "joe"
+        password:
+          type: string
+          description: The new user's password
+          example: "P4ssw0rd!"
+        email:
+          type: string
+          description: The new user's email
+          example: "joe@bloggs.com"
+        fullname:
+          type: string
+          description: The new user's fullname.
+          example: "Joe Bloggs"
+        title:
+          type: string
+          description: The new user's title.
+          example: "Editor"
+          default: "User"
+        state:
+          type: string
+          enum:
+            - enabled
+            - disabled
+          description: Whether or not the user account should be active.
+          default: enabled
+        access:
+          type: object
+          description: The user's access roles
+          properties:
+            admin:
+              type: object
+              properties:
+                login:
+                  type: boolean
+                  example: true
+                super:
+                  type: boolean
+                  example: true
+            site:
+              type: object
+              properties:
+                login:
+                  type: boolean
+                  example: true
+          default:
+            site:
+              login: true
+      required:
+        - username
+        - password
+        - email
+    UserUpdateRequestBody:
+      type: object
+      properties:
+        password:
+          type: string
+          description: The user's existing password
+          example: "P4ssw0rd!"
+        new_password:
+          type: string
+          description: The user's new password
+          example: "P4ssw0rd!"
+        email:
+          type: string
+          description: The user's new email
+          example: "joe@bloggs.com"
+        fullname:
+          type: string
+          description: The user's new fullname.
+          example: "Joe Bloggs"
+        title:
+          type: string
+          description: The user's new title.
+          example: "Editor"
+        state:
+          type: string
+          enum:
+            - enabled
+            - disabled
+          description: Whether or not the user account should be active.
+        access:
+          type: object
+          description: The user's new access roles. Can only be set by an administrator.
+          properties:
+            admin:
+              type: object
+              properties:
+                login:
+                  type: boolean
+                  example: true
+                super:
+                  type: boolean
+                  example: true
+            site:
+              type: object
+              properties:
+                login:
+                  type: boolean
+                  example: true
+      required:
+        - password
   examples:
     InvalidAuthResponse:
       value:

--- a/docs/specification.yaml
+++ b/docs/specification.yaml
@@ -1,0 +1,391 @@
+openapi: 3.0.2
+info:
+  description: The GravCMS Plugin API exposes a REST API on top of your existing GravCMS site that allows you to manipulate the site's content and configuration programmatically.
+  version: 0.0.1
+  title: GravCMS Plugin API
+  contact:
+    name: Plugin Support
+    url: https://github.com/Regaez/grav-plugin-api/issues
+  license:
+    name: MIT
+    url: https://github.com/Regaez/grav-plugin-api/blob/master/LICENSE
+tags:
+  - name: pages
+  - name: config
+  - name: users
+  - name: plugins
+paths:
+  /pages:
+    get:
+      tags:
+        - pages
+      summary: Get all the pages on the site
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  items:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PageResponse'
+                  meta:
+                    $ref: '#/components/schemas/PagesMetadata'
+        401:
+          description: Invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                InvalidAuth:
+                  $ref: '#/components/examples/InvalidAuthResponse'
+    post:
+      tags:
+        - pages
+      summary: Add a new page to the site
+      description: >-
+        In order to create a new page, one must **not** already exist at the specified route.
+
+
+        There are a minimum of two required fields you must provide for the `POST` request to be successful. These are: `route` and `header`. If neither of these are specified, then the page will not be created. Additionally, the `header` field must be **valid JSON**.
+
+
+        There are two further optional fields you may specify: `content` and `template`. If a `template` is not defined, it will fallback to `default`.
+
+        > NOTE: You should **not** include an extension in the template value.
+
+
+        The `content` should be a plain string, formatted using markdown syntax. If no `content` is given, then the page will simply be empty.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PageRequestBody'
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageResponse'
+        400:
+          description: Bad request. You must provide a `route` and a valid `header` field.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                BadRequest:
+                  $ref: '#/components/examples/BadRequestResponse'
+        401:
+          description: Invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                InvalidAuth:
+                  $ref: '#/components/examples/InvalidAuthResponse'
+        403:
+          description: Forbidden. This page already exists.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                Forbidden:
+                  $ref: '#/components/examples/ForbiddenResponse'
+  /pages/{id}:
+    get:
+      tags:
+        - pages
+      summary: Get a specific page
+      parameters:
+        - name: id
+          in: path
+          description: The id/route of the page to return
+          required: true
+          schema:
+            type: string
+            example: "blog/my-first-post"
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageResponse'
+        401:
+          description: Invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                InvalidAuth:
+                  $ref: '#/components/examples/InvalidAuthResponse'
+        404:
+          description: Page not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                NotFound:
+                  $ref: '#/components/examples/NotFoundResponse'
+    patch:
+      tags:
+        - pages
+      summary: Update a specific page
+      description: >-
+        When passing new content via a `PATCH` request, the existing page content will be _entirely overridden_.
+
+
+        Existing `header` information will not be changed, unless the corresponding key is explicitly set. In order to remove an existing field, you must set the field's value to null, such as "custom_field" in the example above.
+
+
+        Setting `template` to a new value will rename the file to the newly specified `template`. If undefined, the template will not be changed.
+      parameters:
+        - name: id
+          in: path
+          description: The id/route of the page to update
+          required: true
+          schema:
+            type: string
+            example: "blog/my-first-post"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PageRequestBody'
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PageResponse'
+        400:
+          description: Bad request. You must provide a `route` field.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                BadRequest:
+                  $ref: '#/components/examples/BadRequestResponse'
+        401:
+          description: Invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                InvalidAuth:
+                  $ref: '#/components/examples/InvalidAuthResponse'
+        404:
+          description: Resource not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                NotFound:
+                  $ref: '#/components/examples/NotFoundResponse'
+    delete:
+      tags:
+        - pages
+      summary: Delete a specific page
+      description: >-
+        If the deletion is successful, the API will respond with a `204` no-content status code.
+
+        > **WARNING:** THIS WILL PERMANENTLY DELETE A PAGE. IT CANNOT BE UNDONE. It is recommended to instead `PATCH` a page and set `"published": false` in the page's `header` if you do not want the page active on your site.
+      parameters:
+        - name: id
+          in: path
+          description: The id/route of the page to delete
+          required: true
+          schema:
+            type: string
+            example: "blog/my-first-post"
+      responses:
+        204:
+          description: Successful operation
+        401:
+          description: Invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                InvalidAuth:
+                  $ref: '#/components/examples/InvalidAuthResponse'
+        404:
+          description: Page not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                NotFound:
+                  $ref: '#/components/examples/NotFoundResponse'
+components:
+  schemas:
+    PageResponse:
+      type: object
+      properties:
+        type:
+          type: string
+          description: The resource type
+          example: "page"
+        id:
+          type: string
+          description: The ID of the page (this is the page's route)
+          example: "blog/my-first-post"
+        attributes:
+          $ref: '#/components/schemas/PageResource'
+        links:
+          $ref: '#/components/schemas/PageHypermedia'
+    PageResource:
+      type: object
+      properties:
+        title:
+          type: string
+          description: The page's title
+          example: "My first post"
+        frontmatter:
+          type: string
+          description: The page's frontmatter, formatted as yaml
+          example: "title: My first post\ncustom_field: You can add custom frontmatter fields, too!"
+        header:
+          type: object
+          description: An object representation of the frontmatter
+          example:
+            title: My first post
+            custom_field: You can add custom frontmatter fields, too!
+        rawMarkdown:
+          type: string
+          description: The page content, formatted as raw markdown text
+          example: "# My first post\n\nThis is some **markdown**."
+        content:
+          type: string
+          description: The page content, formatted as HTML markup
+          example: "<h1>My first post</h1><p>This is some <strong>markdown</strong>.</p>"
+        children:
+          type: array
+          items:
+            type: string
+            description: The route of the child page
+            example: "/blog/my-first-post/child-page"
+          description: An array of routes for the children of the page
+        route:
+          type: string
+          description: The route for this page
+          example: "/blog/my-first-post"
+        slug:
+          type: string
+          description: The slug for the page
+          example: "my-first-post"
+        permalink:
+          type: string
+          description: The URL for the page, including the site domain
+          example: "https://www.mysite.com/blog/my-first-post"
+        template:
+          type: string
+          description: The theme template used for the page
+          example: "post"
+        published:
+          type: boolean
+          description: True or False depending on whether the page has been published
+        date:
+          type: number
+          description: The date/time of when the post was created, as UNIX timestamp
+          example: 1564936730
+        modified:
+          type: number
+          description: The date/time of when the post was last modified, as UNIX timestamp
+          example: 1564936730
+    PageHypermedia:
+      type: object
+      properties:
+        self:
+          type: string
+          description: A link to this resource on the site
+          example: "https://www.mysite.com/blog/my-first-post"
+        related:
+          type: object
+          properties:
+            self:
+              type: string
+              description: A link to this resource through the API
+              example: "https://www.mysite.com/api/pages/blog/my-first-post"
+    PagesMetadata:
+      type: object
+      properties:
+        count:
+          type: number
+          description: The number of pages returned by the request
+          example: 2
+      required:
+        - count
+    PageRequestBody:
+      type: object
+      properties:
+        route:
+          type: string
+          description: The page route to create
+          example: "/the-new-page-slug"
+        header:
+          type: object
+          description: The page frontmatter
+          properties:
+            title:
+              type: string
+              example: "The new page's title"
+            custom_field:
+              type: string
+              example: "You can add custom frontmatter fields, too!"
+          required:
+            - title
+        template:
+          type: string
+          description: The theme template to be used for the page
+          example: "post"
+        content:
+          type: string
+          description: The new page's content, formatted as markdown
+          example: "This is a _new_ page's content in **markdown**!"
+      required:
+        - route
+    ErrorResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          description: A short message describing the error
+          example: "Resource not found"
+        documentation:
+          type: string
+          description: A URL to the documentation for reference
+          example: "https://github.com/regaez/grav-plugin-api/tree/master/docs"
+  examples:
+    InvalidAuthResponse:
+      value:
+        message: "Invalid authentication"
+        documentation: "https://github.com/regaez/grav-plugin-api/tree/master/docs"
+    BadRequestResponse:
+      value:
+        message: "Bad request."
+        documentation: "https://github.com/regaez/grav-plugin-api/tree/master/docs"
+    ForbiddenResponse:
+      value:
+        message: "Forbidden. Resource already exists."
+        documentation: "https://github.com/regaez/grav-plugin-api/tree/master/docs"
+    NotFoundResponse:
+      value:
+        message: "Resource not found"
+        documentation: "https://github.com/regaez/grav-plugin-api/tree/master/docs"


### PR DESCRIPTION
Closes #10 

Create API specification file to document all existing endpoints and functionality:

- [x] `/pages`
- [x] `/users`
- [x] `/plugins`
- [x] `/configs`
