### PR TITLE
chore: setup PHP debugging with xdebug

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Listen for XDebug",
+            "type": "php",
+            "request": "launch",
+            "port": 9073,
+            "pathMappings": {
+              "/var/www/html/user/plugins/api": "${workspaceFolder}"
+            },
+            "log": true,
+            "xdebugSettings": {
+              "max_data": 65535,
+              "show_hidden": 1,
+              "max_children": 100,
+              "max_depth": 5
+            },
+            "externalConsole": false,
+            "ignore": [
+              "${workspaceFolder}/vendor/**/*.php"
+            ]
+        },
+        {
+            "name": "Launch currently open script",
+            "type": "php",
+            "request": "launch",
+            "program": "${file}",
+            "cwd": "${fileDirname}",
+            "port": 9073
+        }
+    ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,23 @@ RUN { \
     echo 'post_max_size=128M'; \
     } > /usr/local/etc/php/conf.d/php-recommended.ini
 
-# provide container inside image for data persistance
-# VOLUME /var/www/html
-
 RUN pecl install apcu \
     && pecl install yaml \
-    && docker-php-ext-enable apcu yaml
+    && pecl install xdebug
+
+RUN { \
+    echo "extension=apcu.so"; \
+    echo "extension=yaml.so"; \
+    echo "zend_extension=$(find /usr/local/lib/php/extensions/ -name xdebug.so)"; \
+    echo '[XDebug]'; \
+    echo 'xdebug.default_enable=1'; \
+    echo 'xdebug.remote_autostart=1'; \
+    echo 'xdebug.remote_connect_back=0'; \
+    echo 'xdebug.remote_enable=1'; \
+    echo 'xdebug.remote_host=host.docker.internal'; \
+    echo 'xdebug.remote_log=/tmp/xdebug.log'; \
+    echo 'xdebug.remote_port=9073'; \
+    } > /usr/local/etc/php/conf.d/php-recommended.ini
 
 # Set user to www-data
 RUN chown www-data:www-data /var/www
@@ -53,9 +64,3 @@ RUN curl -o grav-admin.zip -SL https://getgrav.org/download/core/grav-admin/${GR
 
 # Return to root user
 USER root
-
-# Copy init scripts
-# COPY docker-entrypoint.sh /entrypoint.sh
-
-# ENTRYPOINT ["/entrypoint.sh"]
-# CMD ["apache2-foreground"]

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,11 @@
     "post-install-cmd": "vendor/bin/cghooks add --ignore-lock",
     "post-update-cmd": "vendor/bin/cghooks update",
     "start": "docker-compose -f docker-compose.yaml up -d",
+    "start:clean": [
+      "composer stop",
+      "composer docker:clean",
+      "composer start"
+    ],
     "stop": "docker-compose -f docker-compose.yaml down",
     "test": [
       "./vendor/bin/phpunit --bootstrap vendor/autoload.php --testdox ./tests"


### PR DESCRIPTION
Closes #15 

- Install `xdebug` in docker image 
- Include `.vscode` directory with `launch.json` config for simple debugging configuration
- Add a `composer start:clean` script to stop/remove/start docker image when dockerfile is changed