### PR TITLE
fix: parsing of yaml file for /users endpoints

### DIFF
--- a/src/Handlers/UsersHandler.php
+++ b/src/Handlers/UsersHandler.php
@@ -37,7 +37,7 @@ class UsersHandler extends BaseHandler
             $username = basename($file, '.yaml');
             $details = array_merge(
                 array('username' => $username),
-                Yaml::parse($file)
+                Yaml::parse(file_get_contents($file))
             );
             $resource = new UserResource($details);
             $users[] = $resource->toJson($filter);
@@ -64,7 +64,7 @@ class UsersHandler extends BaseHandler
 
         $resource = new UserResource(array_merge(
             array('username' => basename($file, '.yaml')),
-            Yaml::parse($file)
+            Yaml::parse(file_get_contents($file))
         ));
 
         $filter = null;


### PR DESCRIPTION
Closes #18 

`Yaml::parse()` was expecting the contents of a file, but being given the filepath, so the parsing was not generating a proper array of the user profile.