### PR TITLE
refactor: UserResource extends Resource

### DIFF
--- a/src/Resources/PageCollectionResource.php
+++ b/src/Resources/PageCollectionResource.php
@@ -26,7 +26,7 @@ class PageCollectionResource extends CollectionResource
      * @param  Page $plugin
      * @return PageResource
      */
-    protected function getResource($page)
+    public function getResource($page)
     {
         return new PageResource($page);
     }

--- a/src/Resources/PageResource.php
+++ b/src/Resources/PageResource.php
@@ -181,6 +181,7 @@ class PageResource extends Resource
 
         return $attributes;
     }
+
     /**
      * Returns the resource type
      *

--- a/src/Resources/PluginCollectionResource.php
+++ b/src/Resources/PluginCollectionResource.php
@@ -24,7 +24,7 @@ class PluginCollectionResource extends CollectionResource
      * @param  Plugin $plugin
      * @return PluginResource
      */
-    protected function getResource($plugin)
+    public function getResource($plugin)
     {
         return new PluginResource($plugin);
     }

--- a/src/Resources/UserCollectionResource.php
+++ b/src/Resources/UserCollectionResource.php
@@ -1,0 +1,32 @@
+<?php
+namespace GravApi\Resources;
+
+use Grav\Common\User\User;
+use GravApi\Resources\UserResource;
+
+/**
+ * Class PluginCollectionResource
+ * @package GravApi\Resources
+ */
+class UserCollectionResource extends CollectionResource
+{
+    /**
+     * @param User[] $users
+     */
+    public function __construct($users)
+    {
+        $this->collection = $users;
+    }
+
+    /**
+     * Accepts an resource from the collection and
+     * returns a new PluginResource instance
+     *
+     * @param  User $user
+     * @return UserResource
+     */
+    protected function getResource($user)
+    {
+        return new UserResource($user);
+    }
+}

--- a/src/Resources/UserCollectionResource.php
+++ b/src/Resources/UserCollectionResource.php
@@ -25,7 +25,7 @@ class UserCollectionResource extends CollectionResource
      * @param  User $user
      * @return UserResource
      */
-    protected function getResource($user)
+    public function getResource($user)
     {
         return new UserResource($user);
     }

--- a/tests/Unit/Resources/PageCollectionResourceTest.php
+++ b/tests/Unit/Resources/PageCollectionResourceTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use Codeception\TestCase\Test;
+use Codeception\Util\Fixtures;
+use Grav\Common\Grav;
+use GravApi\Resources\PageResource;
+use GravApi\Resources\PageCollectionResource;
+use GravApi\Config\Config;
+
+final class PageCollectionResourceTest extends Test
+{
+    /** @var Grav $grav */
+    protected $grav;
+
+    /** @var PageCollectionResource $resource */
+    protected $resource;
+
+    protected $route = '/test';
+
+    protected function _before()
+    {
+        $grav = Fixtures::get('grav');
+        $this->grav = $grav();
+
+        Config::instance([
+            'api' => [
+                'route' => 'api',
+                'permalink' => 'http://localhost/api',
+            ],
+            'pages' => [
+                'get' => [
+                    'enabled' => true,
+                    'fields' => []
+                ]
+            ]
+        ]);
+
+        $pages = $this->grav['pages']->all();
+        $this->resource = new PageCollectionResource($pages);
+    }
+
+    public function testGetResourceReturnsPageResource(): void
+    {
+        $page = $this->grav['pages']->find($this->route);
+        $this->assertInstanceOf(
+            PageResource::class,
+            $this->resource->getResource($page)
+        );
+    }
+
+    public function testToJsonReturnsItemsArray(): void
+    {
+        $this->assertIsArray(
+            $this->resource->toJson()['items']
+        );
+    }
+
+    public function testToJsonReturnsMeta(): void
+    {
+        $this->assertIsArray(
+            $this->resource->toJson()['meta']
+        );
+    }
+
+    public function testToJsonReturnsMetaCount(): void
+    {
+        $result = $this->resource->toJson()['meta']['count'];
+        $this->assertEquals(3, $result);
+    }
+}

--- a/tests/Unit/Resources/PageResourceTest.php
+++ b/tests/Unit/Resources/PageResourceTest.php
@@ -69,11 +69,6 @@ final class PageResourceTest extends Test
         );
     }
 
-    /**
-     * TODO: https://github.com/Regaez/grav-plugin-api/issues/36
-     *
-     * Figure out why the `extra` field causes an error running tests
-     */
     public function testGetResourceAttributesReturnsPageData(): void
     {
         $attributes = [
@@ -144,22 +139,6 @@ final class PageResourceTest extends Test
             "unpublishDate" => null,
             "untranslatedLanguages" => [],
             "visible" => false
-        ];
-
-        $this->assertEquals(
-            $attributes,
-            $this->resource->getResourceAttributes()
-        );
-    }
-
-    public function testGetResourceAttributesReturnsPageDataAgain(): void
-    {
-        $this->_before(['title', 'rawMarkdown', 'slug']);
-
-        $attributes = [
-            'title' => 'Test page',
-            'rawMarkdown' => "# Hello {{custom_field}}! This is a test.\n",
-            'slug' => 'test'
         ];
 
         $this->assertEquals(

--- a/tests/Unit/Resources/PageResourceTest.php
+++ b/tests/Unit/Resources/PageResourceTest.php
@@ -80,7 +80,7 @@ final class PageResourceTest extends Test
             "children" => [],
             "childType" => "",
             "content" => "<h1>Hello {{custom_field}}! This is a test.</h1>",
-            "date" => 1565545434,
+            "date" => 1565642012,
             "eTag" => false,
             "expires" => 604800,
             "exists" => true,
@@ -96,7 +96,7 @@ final class PageResourceTest extends Test
                 "custom_field" => "WORLD"
             ],
             "home" => false,
-            "id" => "156554543472ebcd1270d0fccaa9958b7c3952fe87",
+            "id" => "156564201272ebcd1270d0fccaa9958b7c3952fe87",
             "isDir" => false,
             "isFirst" => false,
             "isLast" => false,
@@ -116,7 +116,7 @@ final class PageResourceTest extends Test
                     "name" => "description"
                 ]
             ],
-            "modified" => 1565545434,
+            "modified" => 1565642012,
             "modularTwig" => false,
             "modular" => false,
             "name" => "default.md",
@@ -219,7 +219,7 @@ final class PageResourceTest extends Test
             "children" => [],
             "childType" => "",
             "content" => "<h1>Hello {{custom_field}}! This is a test.</h1>",
-            "date" => 1565545434,
+            "date" => 1565642012,
             "eTag" => false,
             "expires" => 604800,
             "exists" => true,
@@ -235,7 +235,7 @@ final class PageResourceTest extends Test
                 "custom_field" => "WORLD"
             ],
             "home" => false,
-            "id" => "156554543472ebcd1270d0fccaa9958b7c3952fe87",
+            "id" => "156564201272ebcd1270d0fccaa9958b7c3952fe87",
             "isDir" => false,
             "isFirst" => false,
             "isLast" => false,
@@ -255,7 +255,7 @@ final class PageResourceTest extends Test
                     "name" => "description"
                 ]
             ],
-            "modified" => 1565545434,
+            "modified" => 1565642012,
             "modularTwig" => false,
             "modular" => false,
             "name" => "default.md",
@@ -310,7 +310,7 @@ final class PageResourceTest extends Test
             "children" => [],
             "childType" => "",
             "content" => "<h1>Hello {{custom_field}}! This is a test.</h1>",
-            "date" => 1565545434,
+            "date" => 1565642012,
             "eTag" => false,
             "expires" => 604800,
             "exists" => true,
@@ -326,7 +326,7 @@ final class PageResourceTest extends Test
                 "custom_field" => "WORLD"
             ],
             "home" => false,
-            "id" => "156554543472ebcd1270d0fccaa9958b7c3952fe87",
+            "id" => "156564201272ebcd1270d0fccaa9958b7c3952fe87",
             "isDir" => false,
             "isFirst" => false,
             "isLast" => false,
@@ -346,7 +346,7 @@ final class PageResourceTest extends Test
                     "name" => "description"
                 ]
             ],
-            "modified" => 1565545434,
+            "modified" => 1565642012,
             "modularTwig" => false,
             "modular" => false,
             "name" => "default.md",

--- a/tests/Unit/Resources/PluginCollectionResourceTest.php
+++ b/tests/Unit/Resources/PluginCollectionResourceTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use Codeception\TestCase\Test;
+use Codeception\Util\Fixtures;
+use Grav\Common\Grav;
+use GravApi\Resources\PluginResource;
+use GravApi\Resources\PluginCollectionResource;
+use GravApi\Config\Config;
+
+final class PluginCollectionResourceTest extends Test
+{
+    /** @var Grav $grav */
+    protected $grav;
+
+    /** @var PluginCollectionResource $resource */
+    protected $resource;
+
+    protected $id = 'api';
+
+    protected function _before()
+    {
+        $grav = Fixtures::get('grav');
+        $this->grav = $grav();
+
+        Config::instance([
+            'api' => [
+                'route' => 'api',
+                'permalink' => 'http://localhost/api'
+            ]
+        ]);
+
+        $plugins = $this->grav['plugins'];
+        $this->resource = new PluginCollectionResource($plugins);
+    }
+
+    public function testGetResourceReturnsPluginResource(): void
+    {
+        $plugin = $this->grav['plugins']->current();
+        $this->assertInstanceOf(
+            PluginResource::class,
+            $this->resource->getResource($plugin)
+        );
+    }
+
+    public function testToJsonReturnsItemsArray(): void
+    {
+        $this->assertIsArray(
+            $this->resource->toJson()['items']
+        );
+    }
+
+    public function testToJsonReturnsMeta(): void
+    {
+        $this->assertIsArray(
+            $this->resource->toJson()['meta']
+        );
+    }
+
+    public function testToJsonReturnsMetaCount(): void
+    {
+        $result = $this->resource->toJson()['meta']['count'];
+        $this->assertEquals(8, $result);
+    }
+}

--- a/tests/Unit/Resources/PluginResourceTest.php
+++ b/tests/Unit/Resources/PluginResourceTest.php
@@ -5,7 +5,6 @@ use Codeception\TestCase\Test;
 use Codeception\Util\Fixtures;
 use Grav\Common\Grav;
 use Grav\Common\Plugin;
-use GravApi\Api;
 use GravApi\Resources\PluginResource;
 use GravApi\Config\Constants;
 use GravApi\Config\Config;
@@ -20,9 +19,6 @@ final class PluginResourceTest extends Test
 
     /** @var PluginResource $resource */
     protected $resource;
-
-    /** @var Api $api */
-    protected $api;
 
     protected $id = 'api';
 

--- a/tests/Unit/Resources/UserCollectionResourceTest.php
+++ b/tests/Unit/Resources/UserCollectionResourceTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use Codeception\TestCase\Test;
+use Codeception\Util\Fixtures;
+use Grav\Common\Grav;
+use GravApi\Resources\UserResource;
+use GravApi\Resources\UserCollectionResource;
+use GravApi\Config\Config;
+
+final class UserCollectionResourceTest extends Test
+{
+    /** @var Grav $grav */
+    protected $grav;
+
+    /** @var UserCollectionResource $resource */
+    protected $resource;
+
+    protected $username = 'development';
+
+    protected function _before()
+    {
+        $grav = Fixtures::get('grav');
+        $this->grav = $grav();
+
+        Config::instance([
+            'api' => [
+                'route' => 'api',
+                'permalink' => 'http://localhost/api',
+            ],
+            'users' => [
+                'get' => [
+                    'enabled' => true,
+                    'fields' => []
+                ]
+            ]
+        ]);
+
+        $this->user = $this->grav['accounts']->load($this->username);
+        $this->resource = new UserCollectionResource([ $this->user ]);
+    }
+
+    //
+    // TODO: Uncomment once the following issue is resolved:
+    // https://github.com/Regaez/grav-plugin-api/issues/38
+    //
+
+    // public function testGetResourceReturnsUserResource(): void
+    // {
+    //     $this->assertInstanceOf(
+    //         UserResource::class,
+    //         $this->resource->getResource($this->user)
+    //     );
+    // }
+
+    // public function testToJsonReturnsItemsArray(): void
+    // {
+    //     $this->assertIsArray(
+    //         $this->resource->toJson()['items']
+    //     );
+    // }
+
+    // public function testToJsonReturnsMeta(): void
+    // {
+    //     $this->assertIsArray(
+    //         $this->resource->toJson()['meta']
+    //     );
+    // }
+
+    // public function testToJsonReturnsMetaCount(): void
+    // {
+    //     $result = $this->resource->toJson()['meta']['count'];
+    //     $this->assertEquals(1, $result);
+    // }
+}

--- a/tests/Unit/Resources/UserResourceTest.php
+++ b/tests/Unit/Resources/UserResourceTest.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+use Codeception\TestCase\Test;
+use Codeception\Util\Fixtures;
+use Grav\Common\Grav;
+use Grav\Common\User\User;
+use GravApi\Api;
+use GravApi\Resources\UserResource;
+use GravApi\Config\Constants;
+use GravApi\Config\Config;
+
+final class UserResourceTest extends Test
+{
+    /** @var Grav $grav */
+    protected $grav;
+
+    /** @var User $user */
+    protected $user;
+
+    /** @var UserResource $resource */
+    protected $resource;
+
+    /** @var Api $api */
+    protected $api;
+
+    protected $id = 'development';
+
+    protected function _before($attributeFields = array())
+    {
+        $grav = Fixtures::get('grav');
+        $this->grav = $grav();
+
+        Config::instance([
+            'api' => [
+                'route' => 'api',
+                    'permalink' => 'http://localhost/api',
+                ],
+                'users' => [
+                    'get' => [
+                        'enabled' => true,
+                        'fields' => $attributeFields
+                    ]
+                ]
+            ]
+        );
+
+        $this->user = $this->grav['accounts']->load($this->id);
+        $this->resource = new UserResource($this->user);
+    }
+
+    //
+    // TODO: Uncomment other tests once this issue is resolved:
+    // https://github.com/getgrav/grav/issues/2620
+    //
+
+    // public function testGetIdReturnsPluginName(): void
+    // {
+    //     $this->assertEquals(
+    //         $this->id,
+    //         $this->resource->getId()
+    //     );
+    // }
+
+    // public function testGetResourceTypeReturnsUser(): void
+    // {
+    //     $this->assertEquals(
+    //         Constants::TYPE_USER,
+    //         $this->resource->getResourceType()
+    //     );
+    // }
+
+    // public function testGetResourceAttributesReturnsUserData(): void
+    // {
+    //     $attributes = [
+    //         'username' => 'development',
+    //         'email' => 'dummy@email.com',
+    //         'fullname' => 'Development',
+    //         'title' => 'Administrator',
+    //         'state' => 'enabled',
+    //         'access' => [
+    //             'admin' => [
+    //                 'login' => true,
+    //                 'super' => true
+    //             ],
+    //             'site' => [
+    //                 'login' => true
+    //             ]
+    //         ]
+    //     ];
+
+    //     $this->assertEquals(
+    //         $attributes,
+    //         $this->resource->getResourceAttributes()
+    //     );
+    // }
+
+
+    // public function testGetResourceEndpointReturnsExpectedUrl(): void
+    // {
+    //     $this->assertEquals(
+    //         'http://localhost/api/users/',
+    //         $this->resource->getResourceEndpoint()
+    //     );
+    // }
+
+    // public function testGetRelatedSelfReturnsExpectedUrl(): void
+    // {
+    //     $this->assertEquals(
+    //         'http://localhost/api/users/development',
+    //         $this->resource->getRelatedSelf()
+    //     );
+    // }
+
+    // public function testGetRelatedHypermediaReturnsSelfAndResourceUrls(): void
+    // {
+    //     $expected = [
+    //         'self' => 'http://localhost/api/users/development',
+    //         'resource' => 'http://localhost/api/users/'
+    //     ];
+
+    //     $this->assertEquals(
+    //         $expected,
+    //         $this->resource->getRelatedHypermedia()
+    //     );
+    // }
+
+    // public function testGetHypermediaReturnsSelfAndRelatedHypermedia(): void
+    // {
+    //     $expected = [
+    //         'related' => [
+    //             'self' => 'http://localhost/api/users/development',
+    //             'resource' => 'http://localhost/api/users/'
+    //         ]
+    //     ];
+
+    //     $this->assertEquals(
+    //         $expected,
+    //         $this->resource->getHypermedia()
+    //     );
+    // }
+
+    public function testToJsonReturnsResourceObject(): void
+    {
+        $attributes = [
+            'username' => 'development',
+            'email' => 'dummy@email.com',
+            'fullname' => 'Development',
+            'title' => 'Administrator',
+            'state' => 'enabled',
+            'access' => [
+                'admin' => [
+                    'login' => true,
+                    'super' => true
+                ],
+                'site' => [
+                    'login' => true
+                ]
+            ]
+        ];
+
+        $expected = [
+            'type' => Constants::TYPE_USER,
+            'id' => 'development',
+            'attributes' => $attributes,
+            'links' => [
+                'related' => [
+                    'self' => 'http://localhost/api/users/development',
+                    'resource' => 'http://localhost/api/users/'
+                ]
+            ]
+        ];
+
+        $this->assertEquals(
+            $expected,
+            $this->resource->toJson()
+        );
+    }
+
+    // public function testToJsonReturnsAttributesOnly(): void
+    // {
+    //     $expected = [
+    //         'username' => 'development',
+    //         'email' => 'dummy@email.com',
+    //         'fullname' => 'Development',
+    //         'title' => 'Administrator',
+    //         'state' => 'enabled',
+    //         'access' => [
+    //             'admin' => [
+    //                 'login' => true,
+    //                 'super' => true
+    //             ],
+    //             'site' => [
+    //                 'login' => true
+    //             ]
+    //         ]
+    //     ];;
+
+    //     $this->assertEquals(
+    //         $expected,
+    //         $this->resource->toJson(true)
+    //     );
+    // }
+
+    // public function testSetFilterReturnsSpecificResourceFields(): void
+    // {
+    //     $this->_before(['email', 'title', 'state']);
+
+    //     $attributes = [
+    //         'email' => 'dummy@email.com',
+    //         'title' => 'Administrator',
+    //         'state' => 'enabled'
+    //     ];
+
+    //     $expected = [
+    //         'type' => Constants::TYPE_USER,
+    //         'id' => 'development',
+    //         'attributes' => $attributes,
+    //         'links' => [
+    //             'related' => [
+    //                 'self' => 'http://localhost/api/users/development',
+    //                 'resource' => 'http://localhost/api/users/'
+    //             ]
+    //         ]
+    //     ];
+
+    //     $this->assertEquals(
+    //         $expected,
+    //         $this->resource->toJson()
+    //     );
+    // }
+}

--- a/tests/Unit/Resources/UserResourceTest.php
+++ b/tests/Unit/Resources/UserResourceTest.php
@@ -52,7 +52,7 @@ final class UserResourceTest extends Test
 
     //
     // TODO: Uncomment other tests once this issue is resolved:
-    // https://github.com/getgrav/grav/issues/2620
+    // https://github.com/Regaez/grav-plugin-api/issues/38
     //
 
     // public function testGetIdReturnsPluginName(): void


### PR DESCRIPTION
Closes #30 

- Update the `UserResource` to extend the abstract `Resource` class
- Create new `UserCollectionResource` to handle multiples response
- Update `UsersHandler` to use new `$grav['accounts']` method instead of deprecated `User::load` etc