### PR TITLE
refactor: ConfigResource to extend abstract Resource

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -51,16 +51,9 @@ endpoints:
     delete:
       enabled: true
       auth: true
-  plugin:
-    enabled: true
-    auth: true
   plugins:
     enabled: true
     auth: true
-  config:
-    enabled: true
-    auth: true
-    fields: []
   configs:
     enabled: true
     auth: true

--- a/src/Api.php
+++ b/src/Api.php
@@ -140,7 +140,7 @@ class Api
                             ->add(new AuthMiddleware($settings->plugins));
                     }
 
-                    if (!empty($settings->plugin->enabled)) {
+                    if (!empty($settings->plugins->enabled)) {
                         $this->get('/{plugin}', PluginsHandler::class . ':getPlugin')
                             ->add(new AuthMiddleware($settings->plugin));
                     }
@@ -156,7 +156,7 @@ class Api
                             ->add(new AuthMiddleware($settings->configs));
                     }
 
-                    if (!empty($settings->config->enabled)) {
+                    if (!empty($settings->configs->enabled)) {
                         $this->get('/{config}', ConfigHandler::class . ':getConfig')
                             ->add(new AuthMiddleware($settings->config));
                     }

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -15,9 +15,7 @@ class Config
     private $api;
     private $pages;
     private $users;
-    private $plugin;
     private $plugins;
-    private $config;
     private $configs;
 
     /**

--- a/src/Helpers/ConfigHelper.php
+++ b/src/Helpers/ConfigHelper.php
@@ -1,0 +1,69 @@
+<?php
+namespace GravApi\Helpers;
+
+use Grav\Common\Grav;
+use Grav\Common\Config\ConfigFileFinder;
+use GravApi\Models\ConfigModel;
+use GravApi\Resources\ConfigCollectionResource;
+
+/**
+ * Class ConfigHelper
+ * @package GravApi\Helpers
+ */
+class ConfigHelper
+{
+    /**
+     * Returns an array of ConfigModels that can be passed to the ConfigCollectionResource
+     *
+     * @return ConfigModel[]
+     */
+    public static function loadConfigs()
+    {
+        $configs = [];
+
+        // Find all the root config files
+        $location = Grav::instance()['locator']->findResources('config://');
+        $configFiles = (new ConfigFileFinder)->listFiles($location);
+
+        // Retrieve fields of each config file
+        foreach ($configFiles as $name => $value) {
+            $data = Grav::instance()['config']->get($name);
+            if ($data) {
+                $configs[] = ConfigHelper::getConfigObject($name, $data);
+            }
+        }
+
+        return $configs;
+    }
+
+    /**
+     * Returns a ConfigModel for a given config name, or null if it doesn't exist or is on the filter list
+     *
+     * @param string $name
+     * @return ConfigModel|null
+     */
+    public static function loadConfig(string $name)
+    {
+        $data = Grav::instance()['config']->get($name);
+
+        // If the Config doesn't exist, OR it is present on the filter list
+        // (i.e. we don't want to allow user access to it)
+        if (!$data || in_array($name, ConfigCollectionResource::getFilter())) {
+            return null;
+        }
+
+        return ConfigHelper::getConfigObject($name, $data);
+    }
+
+    /**
+     * Returns a Config object that can be passed to the ConfigResource
+     *
+     * @param string $id
+     * @param array $data
+     * @return ConfigModel
+     */
+    public static function getConfigObject(string $id, array $data)
+    {
+        return new ConfigModel($id, $data);
+    }
+}

--- a/src/Helpers/ConfigHelper.php
+++ b/src/Helpers/ConfigHelper.php
@@ -29,7 +29,7 @@ class ConfigHelper
         foreach ($configFiles as $name => $value) {
             $data = Grav::instance()['config']->get($name);
             if ($data) {
-                $configs[] = ConfigHelper::getConfigObject($name, $data);
+                $configs[] = new ConfigModel($name, $data);
             }
         }
 
@@ -52,18 +52,6 @@ class ConfigHelper
             return null;
         }
 
-        return ConfigHelper::getConfigObject($name, $data);
-    }
-
-    /**
-     * Returns a Config object that can be passed to the ConfigResource
-     *
-     * @param string $id
-     * @param array $data
-     * @return ConfigModel
-     */
-    public static function getConfigObject(string $id, array $data)
-    {
-        return new ConfigModel($id, $data);
+        return new ConfigModel($name, $data);
     }
 }

--- a/src/Models/ConfigModel.php
+++ b/src/Models/ConfigModel.php
@@ -1,0 +1,34 @@
+<?php
+namespace GravApi\Models;
+
+/**
+ * Class ConfigModel
+ * @package GravApi\Models
+ */
+class ConfigModel
+{
+    /**
+     * Returns the identifying name of the config
+     *
+     * @return string
+     */
+    protected $id;
+
+    /**
+     * Returns the data array for this config
+     *
+     * @return array
+     */
+    protected $data;
+
+    public function __construct(string $id, array $data)
+    {
+        $this->id = $id;
+        $this->data = $data;
+    }
+
+    public function __get($name)
+    {
+        return $this->{$name};
+    }
+}

--- a/src/Resources/CollectionResource.php
+++ b/src/Resources/CollectionResource.php
@@ -4,28 +4,28 @@ namespace GravApi\Resources;
 abstract class CollectionResource
 {
     protected $collection;
+    protected $filter = array();
 
     abstract protected function getResource($resource);
 
     /**
      * Returns the resource object as an array/json.
-     * Also accepts an array of fields by which to filter.
      *
-     * @param  array $filter optional
-     * @param  bool  $attributes_only optional
      * @return array
      */
-    public function toJson($filter = array(), $attributes_only = false)
+    public function toJson()
     {
         $data = [];
 
         foreach ($this->collection as $item) {
             $resource = $this->getResource($item);
-            $data[] = $resource->toJson();
-        }
 
-        if ($attributes_only) {
-            return $data;
+            // If the item exists in the Resource filter, then we skip it
+            if (in_array($resource->getId(), $this->filter)) {
+                continue;
+            }
+
+            $data[] = $resource->toJson();
         }
 
         // Return Resource object

--- a/src/Resources/ConfigCollectionResource.php
+++ b/src/Resources/ConfigCollectionResource.php
@@ -2,6 +2,8 @@
 namespace GravApi\Resources;
 
 use GravApi\Config\Config;
+use GravApi\Models\ConfigModel;
+use GravApi\Resources\ConfigResource;
 
 /**
  * Class BaseHandler
@@ -9,6 +11,10 @@ use GravApi\Config\Config;
  */
 class ConfigCollectionResource extends CollectionResource
 {
+    /**
+     * @param ConfigModel[] $configs
+     * @return ConfigCollectionResource
+     */
     public function __construct($configs)
     {
         $this->collection = $configs;
@@ -24,10 +30,13 @@ class ConfigCollectionResource extends CollectionResource
     {
         // We don't want to show anyone our security settings!
         $filter = ['security'];
+        $ignore_files = [];
 
         // Check the config for any config files we should ignore in addition
         // to the resource's filter list
-        $ignore_files = Config::instance()->configs->ignore_files;
+        if (Config::instance()->configs) {
+            $ignore_files = Config::instance()->configs->ignore_files;
+        }
 
         if (!empty($ignore_files) && is_array($ignore_files)) {
             return array_merge($filter, $ignore_files);
@@ -41,7 +50,7 @@ class ConfigCollectionResource extends CollectionResource
      * Accepts an resource from the collection and
      * returns a new ConfigResource instance
      *
-     * @param  object $config
+     * @param  ConfigModel $config
      * @return ConfigResource
      */
     public function getResource($config)

--- a/src/Resources/ConfigResource.php
+++ b/src/Resources/ConfigResource.php
@@ -3,6 +3,7 @@ namespace GravApi\Resources;
 
 use GravApi\Config\Config;
 use GravApi\Config\Constants;
+use GravApi\Models\ConfigModel;
 use GravApi\Resources\Resource;
 
 /**
@@ -13,13 +14,14 @@ class ConfigResource extends Resource
 {
     protected $id;
 
-    public function __construct(object $config)
+    /**
+     * @param ConfigModel $config
+     * @return ConfigResource
+     */
+    public function __construct(ConfigModel $config)
     {
         $this->id = $config->id;
         $this->resource = $config->data;
-
-        // Set the attribute filter
-        $this->setFilter();
     }
 
     /**
@@ -76,21 +78,5 @@ class ConfigResource extends Resource
     public function getResourceType()
     {
         return Constants::TYPE_CONFIG;
-    }
-
-    /**
-     * Sets a filter for the list of attributes based on the
-     * API plugin's config setting.
-
-     * @return void
-     */
-    private function setFilter()
-    {
-        $filter = Config::instance()->configs->get['fields'];
-
-        // TODO: improve validation of filter input
-        if ($filter) {
-            $this->filter = $filter;
-        }
     }
 }

--- a/src/Resources/ConfigResource.php
+++ b/src/Resources/ConfigResource.php
@@ -1,7 +1,6 @@
 <?php
 namespace GravApi\Resources;
 
-use GravApi\Config\Config;
 use GravApi\Config\Constants;
 use GravApi\Models\ConfigModel;
 use GravApi\Resources\Resource;
@@ -49,25 +48,11 @@ class ConfigResource extends Resource
     /**
      * Returns the attributes associated with this resource
      *
-     * @param array|null $fields
      * @return array
      */
     public function getResourceAttributes()
     {
-        $attributes = $this->resource;
-
-        // Filter for requested fields
-        if ($this->filter) {
-            $attributes = [];
-
-            foreach ($this->filter as $field) {
-                if (property_exists($this->config, $field)) {
-                    $attributes[$field] = $this->config->{$field};
-                }
-            }
-        }
-
-        return $attributes;
+        return $this->resource;
     }
 
     /**

--- a/src/Resources/PageResource.php
+++ b/src/Resources/PageResource.php
@@ -245,7 +245,11 @@ class PageResource extends Resource
      */
     private function setFilter()
     {
-        $filter = Config::instance()->pages->get['fields'];
+        $filter = null;
+
+        if (Config::instance()->pages) {
+            $filter = Config::instance()->pages->get['fields'];
+        }
 
         // TODO: improve validation of filter input
         if ($filter) {

--- a/src/Resources/PluginResource.php
+++ b/src/Resources/PluginResource.php
@@ -22,6 +22,18 @@ class PluginResource extends Resource
     }
 
     /**
+     * Returns the hypermedia array for this resource
+     *
+     * @return string
+     */
+    public function getHypermedia()
+    {
+        return [
+            'related' => $this->getRelatedHypermedia()
+        ];
+    }
+
+    /**
      * Returns the identifier for this resource
      *
      * @return string
@@ -29,16 +41,6 @@ class PluginResource extends Resource
     public function getId()
     {
         return $this->resource->name;
-    }
-
-    /**
-     * Returns the resource type
-     *
-     * @return string
-     */
-    public function getResourceType()
-    {
-        return Constants::TYPE_PLUGIN;
     }
 
     /**
@@ -53,14 +55,12 @@ class PluginResource extends Resource
     }
 
     /**
-     * Returns the hypermedia array for this resource
+     * Returns the resource type
      *
      * @return string
      */
-    public function getHypermedia()
+    public function getResourceType()
     {
-        return [
-            'related' => $this->getRelatedHypermedia()
-        ];
+        return Constants::TYPE_PLUGIN;
     }
 }

--- a/tests/unit/Helpers/ConfigHelperTest.php
+++ b/tests/unit/Helpers/ConfigHelperTest.php
@@ -1,5 +1,4 @@
 <?php
-
 declare(strict_types=1);
 
 use Codeception\TestCase\Test;

--- a/tests/unit/Helpers/ConfigHelperTest.php
+++ b/tests/unit/Helpers/ConfigHelperTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+use Codeception\TestCase\Test;
+use Codeception\Util\Fixtures;
+use Grav\Common\Grav;
+use GravApi\Config\Config;
+use GravApi\Models\ConfigModel;
+use GravApi\Helpers\ConfigHelper;
+
+final class ConfigHelperTest extends Test
+{
+    /** @var Grav $grav */
+    protected $grav;
+
+    protected function _before($ignore_files = array())
+    {
+        $grav = Fixtures::get('grav');
+        $this->grav = $grav();
+
+        Config::instance([
+            'api' => [
+                'route' => 'api',
+                'permalink' => 'http://localhost/api'
+            ],
+            'configs' => [
+                'ignore_files' => $ignore_files
+            ]
+        ]);
+    }
+
+    public function testLoadConfigsReturnsArrayOfConfigModels(): void
+    {
+        $configs = ConfigHelper::loadConfigs();
+
+        $this->assertIsArray($configs);
+
+        foreach ($configs as $config) {
+            $this->assertInstanceOf(
+                ConfigModel::class,
+                $config
+            );
+        }
+    }
+
+    public function testLoadConfigsReturnsAllConfigFiles(): void
+    {
+        $expectedConfigs = [
+            'site',
+            'security',
+            'streams',
+            'media',
+            'backups',
+            'system'
+        ];
+
+        $configs = ConfigHelper::loadConfigs();
+
+        foreach ($configs as $config) {
+            $this->assertTrue(
+                in_array($config->id, $expectedConfigs)
+            );
+        }
+    }
+
+    public function testLoadConfigReturnsConfigModel(): void
+    {
+        $config = ConfigHelper::loadConfig('site');
+        $this->assertInstanceOf(ConfigModel::class, $config);
+    }
+
+    public function testLoadConfigReturnsNullForSecurityConfig(): void
+    {
+        $config = ConfigHelper::loadConfig('security');
+        $this->assertEquals($config, null);
+    }
+
+    public function testLoadConfigReturnsNullForNoConfig(): void
+    {
+        $config = ConfigHelper::loadConfig('blah');
+        $this->assertEquals($config, null);
+    }
+}

--- a/tests/unit/Models/ConfigModelTest.php
+++ b/tests/unit/Models/ConfigModelTest.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+use Codeception\TestCase\Test;
+use GravApi\Models\ConfigModel;
+
+final class ConfigModelTest extends Test
+{
+    /**
+     * @var ConfigModel $model
+     */
+    protected $model;
+
+    protected function _before()
+    {
+        $this->model = new ConfigModel('id', array('foo' => 'bar'));
+    }
+
+    public function testConfigModelHasStringId(): void
+    {
+        $this->assertIsString($this->model->id);
+    }
+
+    public function testConfigModelIdMatchesGivenId(): void
+    {
+        $this->assertEquals('id', $this->model->id);
+    }
+
+    public function testConfigModelHasArrayData(): void
+    {
+        $this->assertIsArray($this->model->data);
+    }
+
+    public function testConfigModelDataMatchesGivenData(): void
+    {
+        $this->assertEquals(
+            array('foo' => 'bar'),
+            $this->model->data
+        );
+    }
+}

--- a/tests/unit/Resources/ConfigCollectionResourceTest.php
+++ b/tests/unit/Resources/ConfigCollectionResourceTest.php
@@ -17,7 +17,7 @@ final class ConfigCollectionResourceTest extends Test
     /** @var ConfigCollectionResource $resource */
     protected $resource;
 
-    protected function _before()
+    protected function _before($ignore_files = array())
     {
         $grav = Fixtures::get('grav');
         $this->grav = $grav();
@@ -26,6 +26,9 @@ final class ConfigCollectionResourceTest extends Test
             'api' => [
                 'route' => 'api',
                 'permalink' => 'http://localhost/api'
+            ],
+            'configs' => [
+                'ignore_files' => $ignore_files
             ]
         ]);
 
@@ -55,6 +58,16 @@ final class ConfigCollectionResourceTest extends Test
 
         foreach ($configs as $config) {
             $this->assertNotEquals($config['id'], 'security');
+        }
+    }
+
+    public function testToJsonDoesNotReturnIgnoredFiles(): void
+    {
+        $this->_before(['streams']);
+        $configs = $this->resource->toJson()['items'];
+
+        foreach ($configs as $config) {
+            $this->assertNotEquals($config['id'], 'streams');
         }
     }
 

--- a/tests/unit/Resources/ConfigCollectionResourceTest.php
+++ b/tests/unit/Resources/ConfigCollectionResourceTest.php
@@ -1,20 +1,20 @@
 <?php
-
 declare(strict_types=1);
 
 use Codeception\TestCase\Test;
 use Codeception\Util\Fixtures;
 use Grav\Common\Grav;
-use GravApi\Resources\PluginResource;
-use GravApi\Resources\PluginCollectionResource;
 use GravApi\Config\Config;
+use GravApi\Helpers\ConfigHelper;
+use GravApi\Resources\ConfigResource;
+use GravApi\Resources\ConfigCollectionResource;
 
-final class PluginCollectionResourceTest extends Test
+final class ConfigCollectionResourceTest extends Test
 {
     /** @var Grav $grav */
     protected $grav;
 
-    /** @var PluginCollectionResource $resource */
+    /** @var ConfigCollectionResource $resource */
     protected $resource;
 
     protected function _before()
@@ -29,16 +29,16 @@ final class PluginCollectionResourceTest extends Test
             ]
         ]);
 
-        $plugins = $this->grav['plugins'];
-        $this->resource = new PluginCollectionResource($plugins);
+        $configs = ConfigHelper::loadConfigs();
+        $this->resource = new ConfigCollectionResource($configs);
     }
 
-    public function testGetResourceReturnsPluginResource(): void
+    public function testGetResourceReturnsConfigResource(): void
     {
-        $plugin = $this->grav['plugins']->current();
+        $config = ConfigHelper::loadConfig('site');
         $this->assertInstanceOf(
-            PluginResource::class,
-            $this->resource->getResource($plugin)
+            ConfigResource::class,
+            $this->resource->getResource($config)
         );
     }
 
@@ -47,6 +47,15 @@ final class PluginCollectionResourceTest extends Test
         $this->assertIsArray(
             $this->resource->toJson()['items']
         );
+    }
+
+    public function testToJsonDoesNotReturnSecurityConfig(): void
+    {
+        $configs = $this->resource->toJson()['items'];
+
+        foreach ($configs as $config) {
+            $this->assertNotEquals($config['id'], 'security');
+        }
     }
 
     public function testToJsonReturnsMeta(): void
@@ -59,6 +68,6 @@ final class PluginCollectionResourceTest extends Test
     public function testToJsonReturnsMetaCount(): void
     {
         $result = $this->resource->toJson()['meta']['count'];
-        $this->assertEquals(8, $result);
+        $this->assertEquals(5, $result);
     }
 }

--- a/tests/unit/Resources/ConfigResourceTest.php
+++ b/tests/unit/Resources/ConfigResourceTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+use Codeception\TestCase\Test;
+use Codeception\Util\Fixtures;
+use Grav\Common\Grav;
+use GravApi\Config\Config;
+use GravApi\Config\Constants;
+use GravApi\Models\ConfigModel;
+use GravApi\Helpers\ConfigHelper;
+use GravApi\Resources\ConfigResource;
+
+final class ConfigResourceTest extends Test
+{
+    /** @var Grav $grav */
+    protected $grav;
+
+    /** @var ConfigModel $config */
+    protected $config;
+
+    /** @var ConfigResource $resource */
+    protected $resource;
+
+    protected function _before()
+    {
+        $grav = Fixtures::get('grav');
+        $this->grav = $grav();
+
+        Config::instance([
+            'api' => [
+                'route' => 'api',
+                'permalink' => 'http://localhost/api'
+            ]
+        ]);
+
+        $this->config = ConfigHelper::loadConfig('site');
+        $this->resource = new ConfigResource($this->config);
+    }
+
+    public function testGetIdReturnsConfigName(): void
+    {
+        $this->assertEquals(
+            'site',
+            $this->resource->getId()
+        );
+    }
+
+    public function testGetResourceTypeReturnsConfig(): void
+    {
+        $this->assertEquals(
+            Constants::TYPE_CONFIG,
+            $this->resource->getResourceType()
+        );
+    }
+
+    public function testGetResourceAttributesReturnsConfigData(): void
+    {
+        $this->assertEquals(
+            $this->config->data,
+            $this->resource->getResourceAttributes()
+        );
+    }
+
+    public function testGetResourceEndpointReturnsExpectedUrl(): void
+    {
+        $this->assertEquals(
+            'http://localhost/api/configs/',
+            $this->resource->getResourceEndpoint()
+        );
+    }
+
+    public function testGetRelatedSelfReturnsExpectedUrl(): void
+    {
+        $this->assertEquals(
+            'http://localhost/api/configs/site',
+            $this->resource->getRelatedSelf()
+        );
+    }
+
+    public function testGetRelatedHypermediaReturnsSelfAndResourceUrls(): void
+    {
+        $expected = [
+            'self' => 'http://localhost/api/configs/site',
+            'resource' => 'http://localhost/api/configs/'
+        ];
+
+        $this->assertEquals(
+            $expected,
+            $this->resource->getRelatedHypermedia()
+        );
+    }
+
+    public function testGetHypermediaReturnsOnlyRelatedHypermedia(): void
+    {
+        $expected = [
+            'related' => [
+                'self' => 'http://localhost/api/configs/site',
+                'resource' => 'http://localhost/api/configs/'
+            ]
+        ];
+
+        $this->assertEquals(
+            $expected,
+            $this->resource->getHypermedia()
+        );
+    }
+
+    public function testToJsonReturnsResourceObject(): void
+    {
+        $expected = [
+            'type' => Constants::TYPE_CONFIG,
+            'id' => 'site',
+            'attributes' => $this->config->data,
+            'links' => [
+                'related' => [
+                    'self' => 'http://localhost/api/configs/site',
+                    'resource' => 'http://localhost/api/configs/'
+                ]
+            ]
+        ];
+
+        $this->assertEquals(
+            $expected,
+            $this->resource->toJson()
+        );
+    }
+
+    public function testToJsonReturnsAttributesOnly(): void
+    {
+        $expected = $this->config->data;
+
+        $this->assertEquals(
+            $expected,
+            $this->resource->toJson(true)
+        );
+    }
+}


### PR DESCRIPTION
Closes #25 

- Refactors `ConfigResource` to extend abstract `Resource`
- Refactors `ConfigCollectionResource` to extend abstract `CollectionResource`
- Simplifies `ConfigHandler` code after resource refactors
- Adapts `CollectionResource` to allow for filtering specific items from response (e.g. `security` ConfigResource item should not be allowed to be returned by API)
- Creates new `ConfigModel` and `ConfigHelper` classes to simplify and standardise config access
- Adds tests to cover `ConfigCollectionResource` refactor
- Adds tests to cover ConfigResource refactor
- Adds tests to cover new `ConfigModel` and `ConfigHelper` classes