### PR TITLE
chore: update Grav to version 1.6.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,8 +51,8 @@ RUN chown www-data:www-data /var/www
 USER www-data
 
 # Define Grav version and expected SHA1 signature
-ENV GRAV_VERSION 1.6.11
-ENV GRAV_SHA1 5bad00e7884dd1792820e192433bfd1a17b1ec27
+ENV GRAV_VERSION 1.6.13
+ENV GRAV_SHA1 619e2e33f50ac707aca2aac6caa6a989adaa34e4
 
 # Install grav
 WORKDIR /var/www

--- a/tests/unit/Resources/UserCollectionResourceTest.php
+++ b/tests/unit/Resources/UserCollectionResourceTest.php
@@ -41,36 +41,31 @@ final class UserCollectionResourceTest extends Test
         $this->resource = new UserCollectionResource([ $this->user ]);
     }
 
-    //
-    // TODO: Uncomment once the following issue is resolved:
-    // https://github.com/Regaez/grav-plugin-api/issues/38
-    //
+    public function testGetResourceReturnsUserResource(): void
+    {
+        $this->assertInstanceOf(
+            UserResource::class,
+            $this->resource->getResource($this->user)
+        );
+    }
 
-    // public function testGetResourceReturnsUserResource(): void
-    // {
-    //     $this->assertInstanceOf(
-    //         UserResource::class,
-    //         $this->resource->getResource($this->user)
-    //     );
-    // }
+    public function testToJsonReturnsItemsArray(): void
+    {
+        $this->assertIsArray(
+            $this->resource->toJson()['items']
+        );
+    }
 
-    // public function testToJsonReturnsItemsArray(): void
-    // {
-    //     $this->assertIsArray(
-    //         $this->resource->toJson()['items']
-    //     );
-    // }
+    public function testToJsonReturnsMeta(): void
+    {
+        $this->assertIsArray(
+            $this->resource->toJson()['meta']
+        );
+    }
 
-    // public function testToJsonReturnsMeta(): void
-    // {
-    //     $this->assertIsArray(
-    //         $this->resource->toJson()['meta']
-    //     );
-    // }
-
-    // public function testToJsonReturnsMetaCount(): void
-    // {
-    //     $result = $this->resource->toJson()['meta']['count'];
-    //     $this->assertEquals(1, $result);
-    // }
+    public function testToJsonReturnsMetaCount(): void
+    {
+        $result = $this->resource->toJson()['meta']['count'];
+        $this->assertEquals(1, $result);
+    }
 }

--- a/tests/unit/Resources/UserResourceTest.php
+++ b/tests/unit/Resources/UserResourceTest.php
@@ -50,96 +50,91 @@ final class UserResourceTest extends Test
         $this->resource = new UserResource($this->user);
     }
 
-    //
-    // TODO: Uncomment other tests once this issue is resolved:
-    // https://github.com/Regaez/grav-plugin-api/issues/38
-    //
+    public function testGetIdReturnsPluginName(): void
+    {
+        $this->assertEquals(
+            $this->id,
+            $this->resource->getId()
+        );
+    }
 
-    // public function testGetIdReturnsPluginName(): void
-    // {
-    //     $this->assertEquals(
-    //         $this->id,
-    //         $this->resource->getId()
-    //     );
-    // }
+    public function testGetResourceTypeReturnsUser(): void
+    {
+        $this->assertEquals(
+            Constants::TYPE_USER,
+            $this->resource->getResourceType()
+        );
+    }
 
-    // public function testGetResourceTypeReturnsUser(): void
-    // {
-    //     $this->assertEquals(
-    //         Constants::TYPE_USER,
-    //         $this->resource->getResourceType()
-    //     );
-    // }
+    public function testGetResourceAttributesReturnsUserData(): void
+    {
+        $attributes = [
+            'username' => 'development',
+            'email' => 'dummy@email.com',
+            'fullname' => 'Development',
+            'title' => 'Administrator',
+            'state' => 'enabled',
+            'access' => [
+                'admin' => [
+                    'login' => true,
+                    'super' => true
+                ],
+                'site' => [
+                    'login' => true
+                ]
+            ]
+        ];
 
-    // public function testGetResourceAttributesReturnsUserData(): void
-    // {
-    //     $attributes = [
-    //         'username' => 'development',
-    //         'email' => 'dummy@email.com',
-    //         'fullname' => 'Development',
-    //         'title' => 'Administrator',
-    //         'state' => 'enabled',
-    //         'access' => [
-    //             'admin' => [
-    //                 'login' => true,
-    //                 'super' => true
-    //             ],
-    //             'site' => [
-    //                 'login' => true
-    //             ]
-    //         ]
-    //     ];
-
-    //     $this->assertEquals(
-    //         $attributes,
-    //         $this->resource->getResourceAttributes()
-    //     );
-    // }
+        $this->assertEquals(
+            $attributes,
+            $this->resource->getResourceAttributes()
+        );
+    }
 
 
-    // public function testGetResourceEndpointReturnsExpectedUrl(): void
-    // {
-    //     $this->assertEquals(
-    //         'http://localhost/api/users/',
-    //         $this->resource->getResourceEndpoint()
-    //     );
-    // }
+    public function testGetResourceEndpointReturnsExpectedUrl(): void
+    {
+        $this->assertEquals(
+            'http://localhost/api/users/',
+            $this->resource->getResourceEndpoint()
+        );
+    }
 
-    // public function testGetRelatedSelfReturnsExpectedUrl(): void
-    // {
-    //     $this->assertEquals(
-    //         'http://localhost/api/users/development',
-    //         $this->resource->getRelatedSelf()
-    //     );
-    // }
+    public function testGetRelatedSelfReturnsExpectedUrl(): void
+    {
+        $this->assertEquals(
+            'http://localhost/api/users/development',
+            $this->resource->getRelatedSelf()
+        );
+    }
 
-    // public function testGetRelatedHypermediaReturnsSelfAndResourceUrls(): void
-    // {
-    //     $expected = [
-    //         'self' => 'http://localhost/api/users/development',
-    //         'resource' => 'http://localhost/api/users/'
-    //     ];
+    public function testGetRelatedHypermediaReturnsSelfAndResourceUrls(): void
+    {
+        $expected = [
+            'self' => 'http://localhost/api/users/development',
+            'resource' => 'http://localhost/api/users/'
+        ];
 
-    //     $this->assertEquals(
-    //         $expected,
-    //         $this->resource->getRelatedHypermedia()
-    //     );
-    // }
+        $this->assertEquals(
+            $expected,
+            $this->resource->getRelatedHypermedia()
+        );
+    }
 
-    // public function testGetHypermediaReturnsSelfAndRelatedHypermedia(): void
-    // {
-    //     $expected = [
-    //         'related' => [
-    //             'self' => 'http://localhost/api/users/development',
-    //             'resource' => 'http://localhost/api/users/'
-    //         ]
-    //     ];
+    public function testGetHypermediaReturnsSelfAndRelatedHypermedia(): void
+    {
+        $expected = [
+            'related' => [
+                'self' => 'http://localhost/api/users/development',
+                'resource' => 'http://localhost/api/users/'
+            ]
+        ];
 
-    //     $this->assertEquals(
-    //         $expected,
-    //         $this->resource->getHypermedia()
-    //     );
-    // }
+        $this->assertEquals(
+            $expected,
+            $this->resource->getHypermedia()
+        );
+    }
 
     public function testToJsonReturnsResourceObject(): void
     {


### PR DESCRIPTION
Closes #38 

- Updates Grav to version 1.6.13 to get fix blocking `UserResource` test
- Adds more tests for `UserResource` and `UserCollectionResource`