### PR TITLE
tests: cover all Handlers functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,9 @@ install:
     - composer install
 
 script:
-    - composer test:bootstrap
+    - composer start
     - docker-compose exec grav chown -R www-data:www-data .
+    - composer test:bootstrap
     - composer test
 
 before_cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
 
 script:
     - composer test:bootstrap
+    - docker-compose exec grav chown -R www-data:www-data .
     - composer test
 
 before_cache:

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,8 +51,8 @@ RUN chown www-data:www-data /var/www
 USER www-data
 
 # Define Grav version and expected SHA1 signature
-ENV GRAV_VERSION 1.6.13
-ENV GRAV_SHA1 619e2e33f50ac707aca2aac6caa6a989adaa34e4
+ENV GRAV_VERSION 1.6.15
+ENV GRAV_SHA1 ac2a5dff69c4171aea7a0412420aac439f80dd14
 
 # Install grav
 WORKDIR /var/www

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     "squizlabs/php_codesniffer": "^3.4",
     "brainmaestro/composer-git-hooks": "^2.7",
     "codeception/codeception": "^2.4",
-    "overtrue/phplint": "^1.1"
+    "overtrue/phplint": "^1.1",
+    "guzzlehttp/guzzle": "^6.3"
   },
   "scripts": {
     "docker:clean": [

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,7 @@
     "squizlabs/php_codesniffer": "^3.4",
     "brainmaestro/composer-git-hooks": "^2.7",
     "codeception/codeception": "^2.4",
-    "overtrue/phplint": "^1.1",
-    "guzzlehttp/guzzle": "^6.3"
+    "overtrue/phplint": "^1.1"
   },
   "scripts": {
     "docker:clean": [

--- a/src/Handlers/BaseHandler.php
+++ b/src/Handlers/BaseHandler.php
@@ -2,9 +2,6 @@
 namespace GravApi\Handlers;
 
 use Grav\Common\Grav;
-use Interop\Container\ContainerInterface;
-use Psr\Http\Message\ServerRequestInterface as Request;
-use Psr\Http\Message\ResponseInterface as Response;
 use GravApi\Config\Config;
 
 /**
@@ -13,9 +10,6 @@ use GravApi\Config\Config;
  */
 class BaseHandler
 {
-    // Our Slim container
-    protected $container;
-
     // Our grav instance
     protected $grav;
 
@@ -23,9 +17,8 @@ class BaseHandler
     protected $config;
 
     // constructor receives container instance
-    public function __construct(ContainerInterface $container)
+    public function __construct()
     {
-        $this->container = $container;
         $this->grav = Grav::instance();
         $this->config = Config::instance();
     }

--- a/src/Handlers/ConfigHandler.php
+++ b/src/Handlers/ConfigHandler.php
@@ -23,6 +23,10 @@ class ConfigHandler extends BaseHandler
 
     public function getConfig($request, $response, $args)
     {
+        if (!isset($args['config'])) {
+            return $response->withJson(Response::badRequest('No config `id   given!'), 400);
+        }
+
         $config = ConfigHelper::loadConfig($args['config']);
 
         // If the config doesn't exist, OR it is present on the filter list

--- a/src/Handlers/PagesHandler.php
+++ b/src/Handlers/PagesHandler.php
@@ -170,6 +170,14 @@ class PagesHandler extends BaseHandler
 
         // update the page header
         if (!empty($parsedBody['header'])) {
+            if (!is_array($parsedBody['header'])) {
+                $message = "Field `header` must be valid JSON.";
+                return $response->withJson(
+                    Response::badRequest($message),
+                    400
+                );
+            }
+
             $updatedHeader = ArrayHelper::merge(
                 $page->header(),
                 $parsedBody['header']

--- a/src/Handlers/PagesHandler.php
+++ b/src/Handlers/PagesHandler.php
@@ -25,7 +25,11 @@ class PagesHandler extends BaseHandler
 
     public function getPage($request, $response, $args)
     {
-        $route = "/{$request->getAttribute('page')}";
+        if (!isset($args['page'])) {
+            return $response->withJson(Response::badRequest('You must provide an `id` for the page!'), 400);
+        }
+
+        $route = "/{$args['page']}";
         $page = $this->grav['pages']->find($route);
 
         if (!$page) {
@@ -98,7 +102,11 @@ class PagesHandler extends BaseHandler
 
     public function deletePage($request, $response, $args)
     {
-        $route = "/{$request->getAttribute('page')}";
+        if (!isset($args['page'])) {
+            return $response->withJson(Response::badRequest('You must provide an `id` for the page!'), 400);
+        }
+
+        $route = "/{$args['page']}";
         $page = $this->grav['pages']->find($route);
 
         if (!$page || !$page->exists()) {
@@ -146,7 +154,11 @@ class PagesHandler extends BaseHandler
 
     public function updatePage($request, $response, $args)
     {
-        $route = "/{$request->getAttribute('page')}";
+        if (!isset($args['page'])) {
+            return $response->withJson(Response::badRequest('You must provide an `id` for the page!'), 400);
+        }
+
+        $route = "/{$args['page']}";
         $page = $this->grav['pages']->find($route);
 
         if (!$page || !$page->exists()) {
@@ -154,7 +166,10 @@ class PagesHandler extends BaseHandler
         }
 
         $parsedBody = $request->getParsedBody();
-        $template = $parsedBody['template'] ?: '';
+
+        $template = isset($parsedBody['template'])
+            ? $parsedBody['template']
+            : '';
 
         if (empty($parsedBody['route'])) {
             return $response->withJson(Response::badRequest('You must provide a `route` field!'), 400);

--- a/tests/unit/Handlers/ConfigHandlerTest.php
+++ b/tests/unit/Handlers/ConfigHandlerTest.php
@@ -13,6 +13,9 @@ final class ConfigHandlerTest extends Test
     {
         $this->client = new Client([
             'base_uri' => 'http://localhost/api/',
+            'headers' => [
+                'Content-Type' => 'application/json'
+            ],
             'http_errors' => false
         ]);
     }
@@ -26,6 +29,13 @@ final class ConfigHandlerTest extends Test
         $this->assertEquals(200, $response->getStatusCode());
     }
 
+    public function testGetConfigsShouldReturnStatus401(): void
+    {
+        $response = $this->client->get('configs');
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
     public function testGetConfigShouldReturnStatus200(): void
     {
         $response = $this->client->get('configs/site', [
@@ -33,6 +43,13 @@ final class ConfigHandlerTest extends Test
         ]);
 
         $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testGetConfigShouldReturnStatus401(): void
+    {
+        $response = $this->client->get('configs/site');
+
+        $this->assertEquals(401, $response->getStatusCode());
     }
 
     public function testGetConfigShouldReturnStatus404(): void

--- a/tests/unit/Handlers/ConfigHandlerTest.php
+++ b/tests/unit/Handlers/ConfigHandlerTest.php
@@ -49,7 +49,7 @@ final class ConfigHandlerTest extends Test
     {
         $response = $this->client->get('configs/site');
 
-        $this->assertEquals('blah', $response->getBody()->getContents());
+        $this->assertEquals(401, $response->getStatusCode());
     }
 
     public function testGetConfigShouldReturnStatus404(): void

--- a/tests/unit/Handlers/ConfigHandlerTest.php
+++ b/tests/unit/Handlers/ConfigHandlerTest.php
@@ -12,7 +12,7 @@ final class ConfigHandlerTest extends Test
     protected function _before()
     {
         $this->client = new Client([
-            'base_uri' => 'http://localhost/api/',
+            'base_uri' => 'localhost/api/',
             'headers' => [
                 'Content-Type' => 'application/json'
             ],
@@ -49,7 +49,7 @@ final class ConfigHandlerTest extends Test
     {
         $response = $this->client->get('configs/site');
 
-        $this->assertEquals(401, $response->getStatusCode());
+        $this->assertEquals('blah', $response->getBody()->getContents());
     }
 
     public function testGetConfigShouldReturnStatus404(): void

--- a/tests/unit/Handlers/ConfigHandlerTest.php
+++ b/tests/unit/Handlers/ConfigHandlerTest.php
@@ -12,7 +12,7 @@ final class ConfigHandlerTest extends Test
     protected function _before()
     {
         $this->client = new Client([
-            'base_uri' => 'localhost/api/',
+            'base_uri' => 'http://localhost/api/',
             'headers' => [
                 'Content-Type' => 'application/json'
             ],

--- a/tests/unit/Handlers/ConfigHandlerTest.php
+++ b/tests/unit/Handlers/ConfigHandlerTest.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+use Codeception\TestCase\Test;
+use GuzzleHttp\Client;
+
+final class ConfigHandlerTest extends Test
+{
+    /** @var Client $client */
+    protected $client;
+
+    protected function _before()
+    {
+        $this->client = new Client([
+            'base_uri' => 'http://localhost/api/',
+            'http_errors' => false
+        ]);
+    }
+
+    public function testGetConfigsShouldReturnStatus200(): void
+    {
+        $response = $this->client->get('configs', [
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testGetConfigShouldReturnStatus200(): void
+    {
+        $response = $this->client->get('configs/site', [
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testGetConfigShouldReturnStatus404(): void
+    {
+        $response = $this->client->get('configs/blarg', [
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+}

--- a/tests/unit/Handlers/ConfigHandlerTest.php
+++ b/tests/unit/Handlers/ConfigHandlerTest.php
@@ -8,7 +8,6 @@ use Slim\Http\Response;
 use Slim\Http\Environment;
 use Grav\Common\Grav;
 use GravApi\Config\Config;
-use GravApi\Config\Constants;
 use GravApi\Handlers\ConfigHandler;
 
 final class ConfigHandlerTest extends Test
@@ -22,20 +21,12 @@ final class ConfigHandlerTest extends Test
     /** @var ConfigHandler $handler */
     protected $handler;
 
-    protected function _before($ignore_files = array())
+    protected function _before()
     {
         $grav = Fixtures::get('grav');
         $this->grav = $grav();
 
-        Config::instance([
-            'endpoints' => [
-                Constants::ENDPOINT_CONFIG => [
-                    Constants::METHOD_GET => [
-                        'ignore_files' => $ignore_files
-                    ]
-                ]
-            ]
-        ]);
+        Config::instance();
 
         $this->handler = new ConfigHandler();
         $this->response = new Response();

--- a/tests/unit/Handlers/PagesHandlerTest.php
+++ b/tests/unit/Handlers/PagesHandlerTest.php
@@ -12,7 +12,7 @@ final class PagesHandlerTest extends Test
     protected function _before()
     {
         $this->client = new Client([
-            'base_uri' => 'localhost/api/',
+            'base_uri' => 'http://localhost/api/',
             'headers' => [
                 'Content-Type' => 'application/json'
             ],

--- a/tests/unit/Handlers/PagesHandlerTest.php
+++ b/tests/unit/Handlers/PagesHandlerTest.php
@@ -12,7 +12,7 @@ final class PagesHandlerTest extends Test
     protected function _before()
     {
         $this->client = new Client([
-            'base_uri' => 'http://localhost/api/',
+            'base_uri' => 'localhost/api/',
             'headers' => [
                 'Content-Type' => 'application/json'
             ],

--- a/tests/unit/Handlers/PagesHandlerTest.php
+++ b/tests/unit/Handlers/PagesHandlerTest.php
@@ -19,7 +19,7 @@ final class PagesHandlerTest extends Test
     /** @var Response $response */
     protected $response;
 
-    /** @var ConfigHandler $handler */
+    /** @var PagesHandler $handler */
     protected $handler;
 
     protected function _before()

--- a/tests/unit/Handlers/PagesHandlerTest.php
+++ b/tests/unit/Handlers/PagesHandlerTest.php
@@ -1,0 +1,211 @@
+<?php
+declare(strict_types=1);
+
+use Codeception\TestCase\Test;
+use GuzzleHttp\Client;
+
+final class PagesHandlerTest extends Test
+{
+    /** @var Client $client */
+    protected $client;
+
+    protected function _before()
+    {
+        $this->client = new Client([
+            'base_uri' => 'http://localhost/api/',
+            'headers' => [
+                'Content-Type' => 'application/json'
+            ],
+            'http_errors' => false
+        ]);
+    }
+
+    public function testGetPagesShouldReturnStatus200(): void
+    {
+        $response = $this->client->get('pages');
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testGetPageShouldReturnStatus200(): void
+    {
+        $response = $this->client->get('pages/test');
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testGetPageShouldReturnStatus404(): void
+    {
+        $response = $this->client->get('pages/blarg');
+
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+
+    public function testNewPageShouldReturnStatus401IfNoAuth(): void
+    {
+        $response = $this->client->post('pages', [
+            'body' => json_encode([
+                'route' => '/test-page',
+                'header' => [
+                    'title' => 'Test page'
+                ]
+            ])
+        ]);
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    public function testNewPageShouldReturnStatus400IfNoRouteGiven(): void
+    {
+        $response = $this->client->post('pages', [
+            'body' => json_encode([
+                'header' => [
+                    'title' => 'Test page'
+                ]
+            ]),
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    public function testNewPageShouldReturnStatus400IfHeaderNotJson(): void
+    {
+        $response = $this->client->post('pages', [
+            'body' => json_encode([
+                'route' => '/test-page',
+                'header' => 'invalid!'
+            ]),
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    public function testNewPageShouldReturnStatus403IfPageExists(): void
+    {
+        $response = $this->client->post('pages', [
+            'body' => json_encode([
+                'route' => '/test',
+                'header' => [
+                    'title' => 'Test page'
+                ]
+            ]),
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    public function testNewPageShouldReturnStatus200(): void
+    {
+        $response = $this->client->post('pages', [
+            'body' => json_encode([
+                'route' => '/test-page',
+                'header' => [
+                    'title' => 'Test page'
+                ]
+            ]),
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testUpdatePageShouldReturnStatus401IfNoAuth(): void
+    {
+        $response = $this->client->patch('pages/test-page', [
+            'body' => json_encode([
+                'route' => '/test-page',
+                'header' => [
+                    'title' => 'Test page'
+                ]
+            ])
+        ]);
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    public function testUpdatePageShouldReturnStatus400IfNoRouteGiven(): void
+    {
+        $response = $this->client->patch('pages/test-page', [
+            'body' => json_encode([
+                'header' => [
+                    'title' => 'Test page'
+                ]
+            ]),
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    public function testUpdatePageShouldReturnStatus400IfHeaderNotJson(): void
+    {
+        $response = $this->client->patch('pages/test-page', [
+            'body' => json_encode([
+                'route' => '/test-page',
+                'header' => 'invalid!'
+            ]),
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    public function testUpdatePageShouldReturnStatus404IfPageIsNotFound(): void
+    {
+        $response = $this->client->patch('pages/non-existent-page', [
+            'body' => json_encode([
+                'route' => '/non-existent-page',
+                'header' => [
+                    'title' => 'Test page'
+                ]
+            ]),
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+
+    public function testUpdatePageShouldReturnStatus200(): void
+    {
+        $response = $this->client->patch('pages/test-page', [
+            'body' => json_encode([
+                'route' => '/test-page',
+                'header' => [
+                    'title' => 'Test page'
+                ],
+                'content' => 'This is some new content'
+            ]),
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testDeletePageShouldReturnStatus401(): void
+    {
+        $response = $this->client->delete('pages/test-page');
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    public function testDeletePageShouldReturnStatus404(): void
+    {
+        $response = $this->client->delete('pages/blarg', [
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+
+    public function testDeletePageShouldReturnStatus204(): void
+    {
+        $response = $this->client->delete('pages/test-page', [
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(204, $response->getStatusCode());
+    }
+}

--- a/tests/unit/Handlers/PluginsHandlerTest.php
+++ b/tests/unit/Handlers/PluginsHandlerTest.php
@@ -13,6 +13,9 @@ final class PluginsHandlerTest extends Test
     {
         $this->client = new Client([
             'base_uri' => 'http://localhost/api/',
+            'headers' => [
+                'Content-Type' => 'application/json'
+            ],
             'http_errors' => false
         ]);
     }
@@ -26,6 +29,13 @@ final class PluginsHandlerTest extends Test
         $this->assertEquals(200, $response->getStatusCode());
     }
 
+    public function testGetPluginsShouldReturnStatus401(): void
+    {
+        $response = $this->client->get('plugins');
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
     public function testGetPluginShouldReturnStatus200(): void
     {
         $response = $this->client->get('plugins/api', [
@@ -33,6 +43,13 @@ final class PluginsHandlerTest extends Test
         ]);
 
         $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testGetPluginShouldReturnStatus401(): void
+    {
+        $response = $this->client->get('plugins/api');
+
+        $this->assertEquals(401, $response->getStatusCode());
     }
 
     public function testGetPluginShouldReturnStatus404(): void

--- a/tests/unit/Handlers/PluginsHandlerTest.php
+++ b/tests/unit/Handlers/PluginsHandlerTest.php
@@ -2,61 +2,86 @@
 declare(strict_types=1);
 
 use Codeception\TestCase\Test;
-use GuzzleHttp\Client;
+use Codeception\Util\Fixtures;
+use Slim\Http\Request;
+use Slim\Http\Response;
+use Slim\Http\Environment;
+use Grav\Common\Grav;
+use GravApi\Config\Config;
+use GravApi\Handlers\PluginsHandler;
 
 final class PluginsHandlerTest extends Test
 {
-    /** @var Client $client */
-    protected $client;
+    /** @var Grav $client */
+    protected $grav;
+
+    /** @var Response $response */
+    protected $response;
+
+    /** @var PluginsHandler $handler */
+    protected $handler;
 
     protected function _before()
     {
-        $this->client = new Client([
-            'base_uri' => 'http://localhost/api/',
-            'headers' => [
-                'Content-Type' => 'application/json'
-            ],
-            'http_errors' => false
-        ]);
+        $grav = Fixtures::get('grav');
+        $this->grav = $grav();
+
+        Config::instance();
+
+        $this->handler = new PluginsHandler();
+        $this->response = new Response();
     }
 
     public function testGetPluginsShouldReturnStatus200(): void
     {
-        $response = $this->client->get('plugins', [
-            'auth' => ['development', 'D3velopment']
-        ]);
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => '/api/plugins'
+            ])
+        );
+
+        $response = $this->handler->getPlugins($request, $this->response, []);
 
         $this->assertEquals(200, $response->getStatusCode());
-    }
-
-    public function testGetPluginsShouldReturnStatus401(): void
-    {
-        $response = $this->client->get('plugins');
-
-        $this->assertEquals(401, $response->getStatusCode());
     }
 
     public function testGetPluginShouldReturnStatus200(): void
     {
-        $response = $this->client->get('plugins/api', [
-            'auth' => ['development', 'D3velopment']
-        ]);
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => '/api/plugins/api'
+            ])
+        );
+
+        $response = $this->handler->getPlugin(
+            $request,
+            $this->response,
+            [
+                'plugin' => 'api'
+            ]
+        );
 
         $this->assertEquals(200, $response->getStatusCode());
     }
 
-    public function testGetPluginShouldReturnStatus401(): void
-    {
-        $response = $this->client->get('plugins/api');
-
-        $this->assertEquals(401, $response->getStatusCode());
-    }
-
     public function testGetPluginShouldReturnStatus404(): void
     {
-        $response = $this->client->get('plugins/blarg', [
-            'auth' => ['development', 'D3velopment']
-        ]);
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => '/api/plugins/blarg'
+            ])
+        );
+
+        $response = $this->handler->getPlugin(
+            $request,
+            $this->response,
+            [
+                'plugin' => 'blarg'
+            ]
+        );
 
         $this->assertEquals(404, $response->getStatusCode());
     }

--- a/tests/unit/Handlers/PluginsHandlerTest.php
+++ b/tests/unit/Handlers/PluginsHandlerTest.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+use Codeception\TestCase\Test;
+use GuzzleHttp\Client;
+
+final class PluginsHandlerTest extends Test
+{
+    /** @var Client $client */
+    protected $client;
+
+    protected function _before()
+    {
+        $this->client = new Client([
+            'base_uri' => 'http://localhost/api/',
+            'http_errors' => false
+        ]);
+    }
+
+    public function testGetPluginsShouldReturnStatus200(): void
+    {
+        $response = $this->client->get('plugins', [
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testGetPluginShouldReturnStatus200(): void
+    {
+        $response = $this->client->get('plugins/api', [
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testGetPluginShouldReturnStatus404(): void
+    {
+        $response = $this->client->get('plugins/blarg', [
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+}

--- a/tests/unit/Handlers/PluginsHandlerTest.php
+++ b/tests/unit/Handlers/PluginsHandlerTest.php
@@ -12,7 +12,7 @@ final class PluginsHandlerTest extends Test
     protected function _before()
     {
         $this->client = new Client([
-            'base_uri' => 'http://localhost/api/',
+            'base_uri' => 'localhost/api/',
             'headers' => [
                 'Content-Type' => 'application/json'
             ],

--- a/tests/unit/Handlers/PluginsHandlerTest.php
+++ b/tests/unit/Handlers/PluginsHandlerTest.php
@@ -12,7 +12,7 @@ final class PluginsHandlerTest extends Test
     protected function _before()
     {
         $this->client = new Client([
-            'base_uri' => 'localhost/api/',
+            'base_uri' => 'http://localhost/api/',
             'headers' => [
                 'Content-Type' => 'application/json'
             ],

--- a/tests/unit/Handlers/UsersHandlerTest.php
+++ b/tests/unit/Handlers/UsersHandlerTest.php
@@ -12,7 +12,7 @@ final class UsersHandlerTest extends Test
     protected function _before()
     {
         $this->client = new Client([
-            'base_uri' => 'localhost/api/',
+            'base_uri' => 'http://localhost/api/',
             'headers' => [
                 'Content-Type' => 'application/json'
             ],

--- a/tests/unit/Handlers/UsersHandlerTest.php
+++ b/tests/unit/Handlers/UsersHandlerTest.php
@@ -1,0 +1,218 @@
+<?php
+declare(strict_types=1);
+
+use Codeception\TestCase\Test;
+use GuzzleHttp\Client;
+
+final class UsersHandlerTest extends Test
+{
+    /** @var Client $client */
+    protected $client;
+
+    protected function _before()
+    {
+        $this->client = new Client([
+            'base_uri' => 'http://localhost/api/',
+            'headers' => [
+                'Content-Type' => 'application/json'
+            ],
+            'http_errors' => false
+        ]);
+    }
+
+    public function testGetUsersShouldReturnStatus200(): void
+    {
+        $response = $this->client->get('users', [
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testGetUserShouldReturnStatus200(): void
+    {
+        $response = $this->client->get('users/development', [
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testGetUserShouldReturnStatus404(): void
+    {
+        $response = $this->client->get('users/blarg', [
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+
+    public function testNewUserShouldReturnStatus401IfNoAuth(): void
+    {
+        $response = $this->client->post('users', [
+            'body' => json_encode([
+                'username' => 'testuser',
+                'password' => 'Passw0rd!',
+                'email' => 'testuser@test.com'
+            ])
+        ]);
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    public function testNewUserShouldReturnStatus400IfNoUsernameGiven(): void
+    {
+        $response = $this->client->post('users', [
+            'body' => json_encode([
+                'password' => 'Passw0rd!',
+                'email' => 'testuser@test.com'
+            ]),
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    public function testNewUserShouldReturnStatus400IfNoPasswordGiven(): void
+    {
+        $response = $this->client->post('users', [
+            'body' => json_encode([
+                'username' => 'testuser',
+                'email' => 'testuser@test.com'
+            ]),
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    public function testNewUserShouldReturnStatus400IfNoEmailGiven(): void
+    {
+        $response = $this->client->post('users', [
+            'body' => json_encode([
+                'username' => 'testuser',
+                'password' => 'Passw0rd!',
+            ]),
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    public function testNewUserShouldReturnStatus403IfUserExists(): void
+    {
+        $response = $this->client->post('users', [
+            'body' => json_encode([
+                'username' => 'development',
+                'password' => 'Passw0rd!',
+                'email' => 'testuser@test.com'
+            ]),
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(403, $response->getStatusCode());
+    }
+
+    public function testNewUserShouldReturnStatus200(): void
+    {
+        $response = $this->client->post('users', [
+            'body' => json_encode([
+                'username' => 'testuser',
+                'password' => 'Passw0rd!',
+                'email' => 'testuser@test.com'
+            ]),
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testUpdateUserShouldReturnStatus401IfNoAuth(): void
+    {
+        $response = $this->client->patch('users/testuser', [
+            'body' => json_encode([
+                'email' => 'testuser2@test.com'
+            ])
+        ]);
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    public function testUpdateUserShouldReturnStatus400IfNoPasswordGiven(): void
+    {
+        $response = $this->client->patch('users/testuser', [
+            'body' => json_encode([
+                'new_password' => 'Blarg123!'
+            ]),
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    public function testUpdateUserShouldReturnStatus400IfBadPasswordGiven(): void
+    {
+        $response = $this->client->patch('users/testuser', [
+            'body' => json_encode([
+                'new_password' => 'Blarg123!',
+                'password' => 'thisiswrong'
+            ]),
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(400, $response->getStatusCode());
+    }
+
+    public function testUpdateUserShouldReturnStatus404IfNoUserFound(): void
+    {
+        $response = $this->client->patch('users/blarg', [
+            'body' => json_encode([
+                'username' => 'blarg',
+                'password' => 'Passw0rd!',
+                'email' => 'blarg@email.com'
+            ]),
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+
+    public function testUpdateUserShouldReturnStatus200(): void
+    {
+        $response = $this->client->patch('users/testuser', [
+            'body' => json_encode([
+                'new_password' => 'This1sANewPassword!',
+                'password' => 'Passw0rd!',
+                'email' => 'testuser2@test.com'
+            ]),
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testDeleteUserShouldReturnStatus401(): void
+    {
+        $response = $this->client->delete('users/testuser');
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    public function testDeleteUserShouldReturnStatus404(): void
+    {
+        $response = $this->client->delete('users/blarg', [
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+
+    public function testDeleteUserShouldReturnStatus204(): void
+    {
+        $response = $this->client->delete('users/testuser', [
+            'auth' => ['development', 'D3velopment']
+        ]);
+
+        $this->assertEquals(204, $response->getStatusCode());
+    }
+}

--- a/tests/unit/Handlers/UsersHandlerTest.php
+++ b/tests/unit/Handlers/UsersHandlerTest.php
@@ -12,7 +12,7 @@ final class UsersHandlerTest extends Test
     protected function _before()
     {
         $this->client = new Client([
-            'base_uri' => 'http://localhost/api/',
+            'base_uri' => 'localhost/api/',
             'headers' => [
                 'Content-Type' => 'application/json'
             ],

--- a/tests/unit/Helpers/ConfigHelperTest.php
+++ b/tests/unit/Helpers/ConfigHelperTest.php
@@ -5,6 +5,7 @@ use Codeception\TestCase\Test;
 use Codeception\Util\Fixtures;
 use Grav\Common\Grav;
 use GravApi\Config\Config;
+use GravApi\Config\Constants;
 use GravApi\Models\ConfigModel;
 use GravApi\Helpers\ConfigHelper;
 
@@ -17,16 +18,7 @@ final class ConfigHelperTest extends Test
     {
         $grav = Fixtures::get('grav');
         $this->grav = $grav();
-
-        Config::instance([
-            'api' => [
-                'route' => 'api',
-                'permalink' => 'http://localhost/api'
-            ],
-            'configs' => [
-                'ignore_files' => $ignore_files
-            ]
-        ]);
+        Config::instance();
     }
 
     public function testLoadConfigsReturnsArrayOfConfigModels(): void


### PR DESCRIPTION
Closes #47 

Adds tests to cover the `PagesHandler`, `UsersHandler`, `ConfigHandler` and `PluginsHandler` functionality.