### PR TITLE
feat: extend PageResource hypermedia linking

### DIFF
--- a/docs/specification.yaml
+++ b/docs/specification.yaml
@@ -774,6 +774,18 @@ components:
           type: string
           description: A link to this resource on the site
           example: "https://www.mysite.com/blog/my-first-post"
+        children:
+          type: array
+          description: An array of links to this resource's children on the site
+          items:
+            type: string
+          example:
+            - "https://www.mysite.com/blog/my-first-post/child-1"
+            - "https://www.mysite.com/blog/my-first-post/child-2"
+        parent:
+          type: string
+          description: A link to this resource's parent page on the site
+          example: "https://www.mysite.com/blog"
         related:
           type: object
           properties:
@@ -781,6 +793,18 @@ components:
               type: string
               description: A link to this resource through the API
               example: "https://www.mysite.com/api/pages/blog/my-first-post"
+            children:
+              type: array
+              description: An array of links to this resource's children through the API
+              items:
+                type: string
+              example:
+                - "https://www.mysite.com/api/pages/blog/my-first-post/child-1"
+                - "https://www.mysite.com/api/pages/blog/my-first-post/child-2"
+            parent:
+              type: string
+              description: A link to this resource's parent page through the API
+              example: "https://www.mysite.com/api/pages/blog"
     PluginHypermedia:
       type: object
       properties:

--- a/grav/pages/test/01.child/default.md
+++ b/grav/pages/test/01.child/default.md
@@ -1,0 +1,5 @@
+---
+title: 'Test child page'
+---
+
+This is a child page test.

--- a/grav/pages/test/02.another-child/default.md
+++ b/grav/pages/test/02.another-child/default.md
@@ -1,0 +1,5 @@
+---
+title: 'Another child page'
+---
+
+This is a another child page test.

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -24,6 +24,11 @@ class Config
     /**
      * @var string
      */
+    protected $rootUrl;
+
+    /**
+     * @var string
+     */
     protected $permalink;
 
     /**
@@ -217,7 +222,7 @@ class Config
 
     protected function setPermalink()
     {
-        $rootUrl = Grav::instance()['uri']->rootUrl(true);
-        $this->permalink = $rootUrl . '/' . $this->route;
+        $this->rootUrl = Grav::instance()['uri']->rootUrl(true) . '/';
+        $this->permalink = $this->rootUrl . $this->route;
     }
 }

--- a/src/Resources/PageResource.php
+++ b/src/Resources/PageResource.php
@@ -22,6 +22,8 @@ class PageResource extends Resource
     {
         $this->resource = $page;
 
+        $this->setParent();
+
         // Set the attribute filter
         $this->setFilter();
     }
@@ -35,7 +37,24 @@ class PageResource extends Resource
     {
         return [
             'self' => $this->resource->permalink(),
+            'children' => $this->getChildrenHypermedia(),
+            'parent' => $this->getParentHypermedia(),
             'related' => $this->getRelatedHypermedia()
+        ];
+    }
+
+    /**
+     * Returns the releated hypermedia array for this resource type
+     *
+     * @return array
+     */
+    public function getRelatedHypermedia()
+    {
+        return [
+            'self' => $this->getRelatedSelf(),
+            'children' => $this->getChildrenHypermedia(true),
+            'parent' => $this->getParentHypermedia(true),
+            'resource' => $this->getResourceEndpoint()
         ];
     }
 
@@ -126,7 +145,9 @@ class PageResource extends Resource
             'orderDir' => $this->resource->orderDir(),
             'orderBy' => $this->resource->orderBy(),
             'orderManual' => $this->resource->orderManual(),
-            'parent' => $this->resource->parent()->route(),
+
+            // This should be included in hypermedia links
+            // 'parent' => $this->resource->parent()->rawRoute(),
 
             // This would expose server directory structure, so shouldn't be returned
             // 'path' => $this->resource->path(),
@@ -194,6 +215,66 @@ class PageResource extends Resource
     }
 
     /**
+     * Returns the fully qualified children URLs
+     *
+     * @param boolean $related Set true to return API endpoints
+     * @return array
+     */
+    public function getChildrenHypermedia($related = false)
+    {
+        $children = [];
+
+        foreach ($this->processChildren() as $child) {
+            $path = ltrim($child, '/');
+
+            if ($related) {
+                $children[] = $this->getResourceEndpoint() . $path;
+            } else {
+                $children[] = Config::instance()->rootUrl . $path;
+            }
+        }
+
+        return $children;
+    }
+
+    /**
+     * Returns the fully qualified parent URL, or null if no parent exists
+     *
+     * @param boolean $related Set true to return API endpoints
+     * @return string|null
+     */
+    public function getParentHypermedia($related = false)
+    {
+        $parent = $this->resource->parent();
+        $path = ltrim($parent->rawRoute(), '/');
+
+        if (!$parent || !$path) {
+            return null;
+        }
+
+        if ($related) {
+            return $this->getResourceEndpoint() . $path;
+        } else {
+            return Config::instance()->rootUrl . $path;
+        }
+    }
+
+    /**
+     * Sets the parent of the page to the previous route component
+     */
+    private function setParent()
+    {
+        $routeComponents = explode('/', $this->resource->rawRoute());
+        $parentRoute = implode('/', array_slice($routeComponents, 0, -1));
+
+        $parent = Grav::instance()['pages']->find($parentRoute);
+
+        if ($parent) {
+            $this->resource->parent($parent);
+        }
+    }
+
+    /**
      * We process the children because the collection's
      * toArray method will expose our server directory structure
      *
@@ -204,7 +285,7 @@ class PageResource extends Resource
         $children = [];
         foreach ($this->resource->children()->toArray() as $child) {
             // we generate the routes for each child
-            $children[] = $this->resource->route().'/'.$child['slug'];
+            $children[] = $this->resource->rawRoute().'/'.$child['slug'];
         }
         return $children;
     }

--- a/tests/unit/Resources/PageCollectionResourceTest.php
+++ b/tests/unit/Resources/PageCollectionResourceTest.php
@@ -56,6 +56,6 @@ final class PageCollectionResourceTest extends Test
     public function testToJsonReturnsMetaCount(): void
     {
         $result = $this->resource->toJson()['meta']['count'];
-        $this->assertEquals(3, $result);
+        $this->assertEquals(5, $result);
     }
 }

--- a/tests/unit/Resources/PageResourceTest.php
+++ b/tests/unit/Resources/PageResourceTest.php
@@ -70,7 +70,10 @@ final class PageResourceTest extends Test
     public function testGetResourceAttributesReturnsPageData(): void
     {
         $attributes = [
-            "children" => [],
+            "children" => [
+                "/test/child",
+                "/test/another-child"
+            ],
             "childType" => "",
             "content" => "<h1>Hello {{custom_field}}! This is a test.</h1>",
             "date" => 1565642012,
@@ -117,7 +120,6 @@ final class PageResourceTest extends Test
             "orderDir" => "asc",
             "orderBy" => "default",
             "orderManual" => [],
-            "parent" => null,
             "permalink" => "http://localhost/test",
             "publishDate" => null,
             "published" => true,
@@ -260,10 +262,6 @@ final class PageResourceTest extends Test
             $result['orderManual']
         );
         $this->assertEquals(
-            $attributes['parent'],
-            $result['parent']
-        );
-        $this->assertEquals(
             $attributes['permalink'],
             $result['permalink']
         );
@@ -361,6 +359,11 @@ final class PageResourceTest extends Test
     {
         $expected = [
             'self' => 'http://localhost/api/pages/test',
+            'children' => [
+                'http://localhost/api/pages/test/child',
+                'http://localhost/api/pages/test/another-child'
+            ],
+            'parent' => null,
             'resource' => 'http://localhost/api/pages/'
         ];
 
@@ -374,8 +377,18 @@ final class PageResourceTest extends Test
     {
         $expected = [
             'self' => 'http://localhost/test',
+            'children' => [
+                'http://localhost/test/child',
+                'http://localhost/test/another-child'
+            ],
+            'parent' => null,
             'related' => [
                 'self' => 'http://localhost/api/pages/test',
+                'children' => [
+                    'http://localhost/api/pages/test/child',
+                    'http://localhost/api/pages/test/another-child'
+                ],
+                'parent' => null,
                 'resource' => 'http://localhost/api/pages/'
             ]
         ];
@@ -394,8 +407,18 @@ final class PageResourceTest extends Test
             'attributes' => $this->resource->getResourceAttributes(),
             'links' => [
                 'self' => 'http://localhost/test',
+                'children' => [
+                    'http://localhost/test/child',
+                    'http://localhost/test/another-child'
+                ],
+                'parent' => null,
                 'related' => [
                     'self' => 'http://localhost/api/pages/test',
+                    'children' => [
+                        'http://localhost/api/pages/test/child',
+                        'http://localhost/api/pages/test/another-child'
+                    ],
+                    'parent' => null,
                     'resource' => 'http://localhost/api/pages/'
                 ]
             ]
@@ -431,8 +454,18 @@ final class PageResourceTest extends Test
             'attributes' => $attributes,
             'links' => [
                 'self' => 'http://localhost/test',
+                'children' => [
+                    'http://localhost/test/child',
+                    'http://localhost/test/another-child'
+                ],
+                'parent' => null,
                 'related' => [
                     'self' => 'http://localhost/api/pages/test',
+                    'children' => [
+                        'http://localhost/api/pages/test/child',
+                        'http://localhost/api/pages/test/another-child'
+                    ],
+                    'parent' => null,
                     'resource' => 'http://localhost/api/pages/'
                 ]
             ]


### PR DESCRIPTION
Closes #54 

Adds `children` and `parent` properties to the `links` object for every PageResource.