### PR TITLE
fix: only show enabled endpoints on root /api/

### DIFF
--- a/src/Api.php
+++ b/src/Api.php
@@ -58,23 +58,9 @@ class Api
 
             $this->get('', function ($request, $response, $args) {
                 $config = Config::instance();
+                $endpoints = $config->getEnabledResourceEndpoints();
 
-                $urls = [
-                    Constants::TYPE_PAGE => $config->getEndpoint(
-                        Constants::TYPE_PAGE
-                    ),
-                    Constants::TYPE_USER => $config->getEndpoint(
-                        Constants::TYPE_USER
-                    ),
-                    Constants::TYPE_PLUGIN => $config->getEndpoint(
-                        Constants::TYPE_PLUGIN
-                    ),
-                    Constants::TYPE_CONFIG => $config->getEndpoint(
-                        Constants::TYPE_CONFIG
-                    )
-                ];
-
-                return $response->withJson($urls);
+                return $response->withJson($endpoints);
             });
 
             $config = Config::instance();

--- a/src/Config/Config.php
+++ b/src/Config/Config.php
@@ -48,7 +48,7 @@ class Config
 
     /**
      * We map all settings to existing class properties
-     * @param [array] $settings
+     * @param array $settings
      */
     private function __construct($config = null)
     {
@@ -146,8 +146,8 @@ class Config
      * and returns the matching, fully-qualified endpoint
      * for the given Resource Type.
      *
-     * @param  [string] $resourceType e.g. Constants::TYPE_PAGE
-     * @return [string] e.g. https://www.example.com/api/pages/
+     * @param  string $resourceType e.g. Constants::TYPE_PAGE
+     * @return string e.g. https://www.example.com/api/pages/
      */
     public function getEndpoint(string $resourceType)
     {
@@ -169,6 +169,50 @@ class Config
         }
 
         return $this->permalink . $endpoint . '/';
+    }
+
+    /**
+     * Accepts one of the Constants::TYPE_* as a parameter,
+     * and returns the matching endpoint config class
+     * for the given Resource Type.
+     *
+     * @param  string $resourceType e.g. Constants::TYPE_PAGE
+     * @return Endpoint
+     */
+    public function getEndpointConfigByType(string $resourceType)
+    {
+        switch ($resourceType) {
+            case Constants::TYPE_PAGE:
+                return $this->pages;
+            case Constants::TYPE_USER:
+                return $this->users;
+            case Constants::TYPE_PLUGIN:
+                return $this->plugins;
+            case Constants::TYPE_CONFIG:
+                return $this->configs;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns associative array of available resource types
+     * with API endpoint to access resource
+     *
+     * @return array
+     */
+    public function getEnabledResourceEndpoints()
+    {
+        $endpoints = [];
+
+        foreach (Constants::TYPES as $type) {
+            $config = $this->getEndpointConfigByType($type);
+            if ($config->get->enabled) {
+                $endpoints[$type] = $this->getEndpoint($type);
+            }
+        }
+
+        return $endpoints;
     }
 
     protected function setPermalink()

--- a/src/Config/Constants.php
+++ b/src/Config/Constants.php
@@ -15,6 +15,14 @@ class Constants
     const TYPE_PLUGIN = 'plugin';
     const TYPE_CONFIG = 'config';
 
+    // All available types
+    const TYPES = [
+        Constants::TYPE_PAGE,
+        Constants::TYPE_USER,
+        Constants::TYPE_PLUGIN,
+        Constants::TYPE_CONFIG
+    ];
+
     // Endpoints
     const ENDPOINT_PAGE = '/pages';
     const ENDPOINT_USER = '/users';

--- a/tests/unit/Config/ConfigTest.php
+++ b/tests/unit/Config/ConfigTest.php
@@ -108,4 +108,26 @@ final class ConfigTest extends Test
         $this->assertEquals('blah', $config->route);
         Config::resetInstance();
     }
+
+    public function testGetEndpointConfigByTypeReturnsClass(): void
+    {
+        $config = Config::instance();
+
+        $this->assertEquals(
+            $config->pages,
+            $config->getEndpointConfigByType(Constants::TYPE_PAGE)
+        );
+        $this->assertEquals(
+            $config->users,
+            $config->getEndpointConfigByType(Constants::TYPE_USER)
+        );
+        $this->assertEquals(
+            $config->configs,
+            $config->getEndpointConfigByType(Constants::TYPE_CONFIG)
+        );
+        $this->assertEquals(
+            $config->plugins,
+            $config->getEndpointConfigByType(Constants::TYPE_PLUGIN)
+        );
+    }
 }


### PR DESCRIPTION
Closes #53 