### PR TITLE
feat: enable role based permissions per endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,10 @@ vendor
 logs
 cghooks.lock
 build
+
+# Ignore config files we don't care about
+grav/config/backups.yaml
+grav/config/media.yaml
+grav/config/scheduler.yaml
+grav/config/security.yaml
+grav/config/streams.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ logs
 cghooks.lock
 build
 
-# Ignore config files we don't care about
+# Ignore config files we don't care about for now
 grav/config/backups.yaml
 grav/config/media.yaml
 grav/config/scheduler.yaml

--- a/api.php
+++ b/api.php
@@ -3,6 +3,7 @@ namespace Grav\Plugin;
 
 use Grav\Common\Plugin;
 use RocketTheme\Toolbox\Event\Event;
+use GravApi\Config\Constants;
 
 /**
  * Class ApiPlugin
@@ -25,8 +26,11 @@ class ApiPlugin extends Plugin
      */
     public static function getSubscribedEvents()
     {
+        require_once __DIR__ . '/vendor/autoload.php';
+
         return [
-            'onPluginsInitialized' => ['onPluginsInitialized', 0]
+            'onPluginsInitialized' => ['onPluginsInitialized', 0],
+            'onAdminRegisterPermissions' => ['onAdminRegisterPermissions', 0]
         ];
     }
 
@@ -69,6 +73,24 @@ class ApiPlugin extends Plugin
     }
 
     /**
+     * Register custom API role permissions
+     *
+     * @param Event $e
+     */
+    public function onAdminRegisterPermissions(Event $e)
+    {
+        if (isset($e['admin'])) {
+            $permissions = [];
+
+            foreach (Constants::ROLES as $role) {
+                $permissions[$role] = 'boolean';
+            }
+
+            $e['admin']->addPermissions($permissions);
+        }
+    }
+
+    /**
      * Loads the GravApi dependencies and returns a new instance the Api app
      *
      * @return GravApi\Api $api
@@ -76,7 +98,6 @@ class ApiPlugin extends Plugin
     public function loadApi()
     {
         // Load app dependencies once we know the request is for the API
-        require_once __DIR__ . '/vendor/autoload.php';
         require_once __DIR__ . '/src/Api.php';
 
         return new \GravApi\Api();

--- a/api.yaml
+++ b/api.yaml
@@ -42,6 +42,7 @@ endpoints:
         - title
         - state
         - access
+        - groups
     post:
       enabled: true
       auth: true

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -8,6 +8,7 @@ You will need to install the following:
 - [composer](https://getcomposer.org/download/) (set up so you can simply [run `composer` anywhere](https://getcomposer.org/doc/00-intro.md#globally))
 - [docker + docker-compose](https://docs.docker.com/compose/install/)
 
+
 ## Local development
 
 For ease of use, the project is set up to run Grav in Docker. The project layout is such:
@@ -40,10 +41,72 @@ There are a number of scripts set up to make development easier:
 - `composer test`: Runs the unit tests.
 - `composer docker:clean`: Deletes the existing docker development environment.
 
-### Admin Credentials
 
-If you need to log into the grav admin interface for the local development environment, the default credentials are valid with _administrator_ privileges:
+### User Accounts
+
+There are a few different dummy user accounts available for local testing. These accounts can be used to authenticate API requests using the `Basic` authentication type.
+
+
+#### Admin Credentials
+
+If you need to log into the grav admin interface for the local development environment, the following credentials are valid with _admin.super_ privileges (which also allows access to all API resources):
 
 > **Username:** `development`
 >
 > **Password:** `D3velopment`
+
+
+#### Testing Permissions
+
+The following accounts have various levels role permissions set. For simplicity, they all share the same password as the **admin account above**:
+
+---
+
+> **Username:** `percy`
+
+_Percy "Permit All"_ can access all resources in the API. The account includes the following roles:
+
+- `api.pages_read`
+- `api.pages_delete`
+- `api.pages_edit`
+- `api.pages_create`
+- `api.users_read`
+- `api.users_delete`
+- `api.users_create`
+- `api.users_edit`
+- `api.plugins_read`
+- `api.plugins_edit`
+- `api.plugins_install`
+- `api.plugins_uninstall`
+- `api.configs_read`
+- `api.configs_edit`
+- `admin.login`
+- `site.login`
+
+---
+
+> **Username:** `joe`
+
+_"No-go" Joe_ cannot do anything with the API where authentication is required. THe account includes the following roles:
+
+- `admin.login`
+- `site.login`
+
+---
+
+> **Username:** `andy`
+
+_"Admin" Andy_ inherits his permissions from the Grav group `siteadmins`. The _group_ includes the following roles:
+
+- `api.users_read`
+- `api.users_delete`
+- `api.users_create`
+- `api.users_edit`
+- `api.plugins_read`
+- `api.plugins_edit`
+- `api.plugins_install`
+- `api.plugins_uninstall`
+- `api.configs_read`
+- `api.configs_edit`
+- `admin.login`
+- `site.login`

--- a/docs/specification.yaml
+++ b/docs/specification.yaml
@@ -953,24 +953,9 @@ components:
           description: The user's title
           example: "Administrator"
         access:
-          type: object
-          description: The user's access roles
-          properties:
-            admin:
-              type: object
-              properties:
-                login:
-                  type: boolean
-                  example: true
-                super:
-                  type: boolean
-                  example: true
-            site:
-              type: object
-              properties:
-                login:
-                  type: boolean
-                  example: true
+          $ref: '#/components/schemas/UserResourceAccessProperty'
+        groups:
+          $ref: '#/components/schemas/UserResourceGroupsProperty'
     UserRequestBody:
       type: object
       properties:
@@ -1003,27 +988,9 @@ components:
           description: Whether or not the user account should be active.
           default: enabled
         access:
-          type: object
-          description: The user's access roles
-          properties:
-            admin:
-              type: object
-              properties:
-                login:
-                  type: boolean
-                  example: true
-                super:
-                  type: boolean
-                  example: true
-            site:
-              type: object
-              properties:
-                login:
-                  type: boolean
-                  example: true
-          default:
-            site:
-              login: true
+          $ref: '#/components/schemas/UserResourceAccessProperty'
+        groups:
+          $ref: '#/components/schemas/UserResourceGroupsProperty'
       required:
         - username
         - password
@@ -1058,26 +1025,103 @@ components:
             - disabled
           description: Whether or not the user account should be active.
         access:
-          type: object
-          description: The user's new access roles. Can only be set by an administrator.
-          properties:
-            admin:
-              type: object
-              properties:
-                login:
-                  type: boolean
-                  example: true
-                super:
-                  type: boolean
-                  example: true
-            site:
-              type: object
-              properties:
-                login:
-                  type: boolean
-                  example: true
+          $ref: '#/components/schemas/UserResourceAccessProperty'
+        groups:
+          $ref: '#/components/schemas/UserResourceGroupsProperty'
       required:
         - password
+    UserResourceGroupsProperty:
+      type: array
+      description: The Grav groups to which the user belongs. These are defined in the grav/user/config/groups.yaml file.
+      items:
+        type: string
+      example: ["administrators"]
+    UserResourceAccessProperty:
+      type: object
+      description: The user's new access roles. Can only be set by an administrator.
+      properties:
+        admin:
+          type: object
+          properties:
+            login:
+              type: boolean
+              example: true
+            super:
+              type: boolean
+              description: This role will also grant access to ALL API resources
+              example: true
+        api:
+          type: object
+          properties:
+            super:
+              type: boolean
+              description: Grants access to ALL API resources
+              example: true
+            pages_read:
+              type: boolean
+              description: Grants access to read page resources
+              example: true
+            pages_delete:
+              type: boolean
+              description: Grants access to delete page resources
+              example: true
+            pages_edit:
+              type: boolean
+              description: Grants access to edit page resources
+              example: true
+            pages_create:
+              type: boolean
+              description: Grants access to create page resources
+              example: true
+            users_read:
+              type: boolean
+              description: Grants access to read user resources
+              example: true
+            users_delete:
+              type: boolean
+              description: Grants access to delete user resources
+              example: true
+            users_create:
+              type: boolean
+              description: Grants access to create user resources
+              example: true
+            users_edit:
+              type: boolean
+              description: Grants access to edit user resources
+              example: true
+            plugins_read:
+              type: boolean
+              description: Grants access to read plugin resources
+              example: true
+            plugins_edit:
+              type: boolean
+              description: Grants access to edit plugin resources
+              example: true
+            plugins_install:
+              type: boolean
+              description: Grants access to install new plugins
+              example: true
+            plugins_uninstall:
+              type: boolean
+              description: Grants access to uninstall existing plugins
+              example: true
+            configs_read:
+              type: boolean
+              description: Grants access to read config resources
+              example: true
+            configs_edit:
+              type: boolean
+              description: Grants access to edit config resources
+              example: true
+        site:
+          type: object
+          properties:
+            login:
+              type: boolean
+              example: true
+      default:
+            site:
+              login: true
   examples:
     InvalidAuthResponse:
       value:

--- a/grav/accounts/andy.yaml
+++ b/grav/accounts/andy.yaml
@@ -1,0 +1,7 @@
+email: andy@email.com
+fullname: Andy Admin
+title: Permissions Tester
+state: enabled
+groups:
+  - siteadmin
+hashed_password: $2y$10$aIw9wIWgj6bVuOk.sGRgw.TSZFOkIFmteDOLUFNj5Uka4ugxp5cTu

--- a/grav/accounts/development.yaml
+++ b/grav/accounts/development.yaml
@@ -2,6 +2,7 @@ email: dummy@email.com
 fullname: Development
 title: Administrator
 state: enabled
+custom: this is a custom field
 access:
   admin:
     login: true

--- a/grav/accounts/joe.yaml
+++ b/grav/accounts/joe.yaml
@@ -1,0 +1,26 @@
+email: joe@email.com
+fullname: No-Go Joe
+title: Permissions Tester
+state: enabled
+access:
+  api:
+    pages_read: false
+    pages_delete: false
+    pages_edit: false
+    pages_create: false
+    users_read: false
+    users_delete: false
+    users_create: false
+    users_edit: false
+    plugins_read: false
+    plugins_edit: false
+    plugins_install: false
+    plugins_uninstall: false
+    configs_read: false
+    configs_edit: false
+  admin:
+    super: false
+    login: true
+  site:
+    login: true
+hashed_password: $2y$10$aIw9wIWgj6bVuOk.sGRgw.TSZFOkIFmteDOLUFNj5Uka4ugxp5cTu

--- a/grav/accounts/percy.yaml
+++ b/grav/accounts/percy.yaml
@@ -1,0 +1,26 @@
+email: percy@email.com
+fullname: Percy Permit
+title: Permissions Tester
+state: enabled
+access:
+  api:
+    pages_read: true
+    pages_delete: true
+    pages_edit: true
+    pages_create: true
+    users_read: true
+    users_delete: true
+    users_create: true
+    users_edit: true
+    plugins_read: true
+    plugins_edit: true
+    plugins_install: true
+    plugins_uninstall: true
+    configs_read: true
+    configs_edit: true
+  admin:
+    super: false
+    login: true
+  site:
+    login: true
+hashed_password: $2y$10$aIw9wIWgj6bVuOk.sGRgw.TSZFOkIFmteDOLUFNj5Uka4ugxp5cTu

--- a/grav/config/groups.yaml
+++ b/grav/config/groups.yaml
@@ -1,0 +1,20 @@
+siteadmin:
+  readableName: Site Administrators
+  description: 'The group of site administrators'
+  icon: child
+  access:
+    api:
+      users_read: true
+      users_delete: true
+      users_create: true
+      users_edit: true
+      plugins_read: true
+      plugins_edit: true
+      plugins_install: true
+      plugins_uninstall: true
+      configs_read: true
+      configs_edit: true
+    admin:
+      login: true
+    site:
+      login: true

--- a/grav/config/system.yaml
+++ b/grav/config/system.yaml
@@ -12,14 +12,14 @@ pages:
     twig: false
 
 cache:
-  enabled: true
+  enabled: false
   check:
     method: file
   driver: auto
   prefix: 'g'
 
 twig:
-  cache: true
+  cache: false
   debug: true
   auto_reload: true
   autoescape: false

--- a/src/Api.php
+++ b/src/Api.php
@@ -59,7 +59,6 @@ class Api
             $this->get('', function ($request, $response, $args) {
                 $config = Config::instance();
                 $endpoints = $config->getEnabledResourceEndpoints();
-
                 return $response->withJson($endpoints);
             });
 
@@ -71,31 +70,61 @@ class Api
 
                     if ($config->pages->get->enabled) {
                         $this->get('', PagesHandler::class . ':getPages')
-                            ->add(new AuthMiddleware($config->pages->get));
+                        ->add(
+                            new AuthMiddleware(
+                                $config->pages->get,
+                                [Constants::ROLE_PAGES_READ]
+                            )
+                        );
 
                         $this->get('/{page:.*}', PagesHandler::class . ':getPage')
-                            ->add(new AuthMiddleware($config->pages->get));
+                        ->add(
+                            new AuthMiddleware(
+                                $config->pages->get,
+                                [Constants::ROLE_PAGES_READ]
+                            )
+                        );
                     }
 
                     // TODO: add more fine-grained enabling/disabling support for sub-endpoints to avoid confusion
                     if ($config->pages->get->enabled) {
                         $this->post('/searches', PagesHandler::class . ':findPages')
-                            ->add(new AuthMiddleware($config->pages->get));
+                        ->add(
+                            new AuthMiddleware(
+                                $config->pages->get,
+                                [Constants::ROLE_PAGES_READ]
+                            )
+                        );
                     }
 
                     if ($config->pages->post->enabled) {
                         $this->post('', PagesHandler::class . ':newPage')
-                            ->add(new AuthMiddleware($config->pages->post));
+                        ->add(
+                            new AuthMiddleware(
+                                $config->pages->post,
+                                [Constants::ROLE_PAGES_CREATE]
+                            )
+                        );
                     }
 
                     if ($config->pages->delete->enabled) {
                         $this->delete('/{page:.*}', PagesHandler::class . ':deletePage')
-                            ->add(new AuthMiddleware($config->pages->delete));
+                        ->add(
+                            new AuthMiddleware(
+                                $config->pages->delete,
+                                [Constants::ROLE_PAGES_DELETE]
+                            )
+                        );
                     }
 
                     if ($config->pages->patch->enabled) {
                         $this->patch('/{page:.*}', PagesHandler::class . ':updatePage')
-                            ->add(new AuthMiddleware($config->pages->patch));
+                        ->add(
+                            new AuthMiddleware(
+                                $config->pages->patch,
+                                [Constants::ROLE_PAGES_EDIT]
+                            )
+                        );
                     }
                 }
             );
@@ -106,25 +135,50 @@ class Api
 
                     if ($config->users->get->enabled) {
                         $this->get('', UsersHandler::class . ':getUsers')
-                            ->add(new AuthMiddleware($config->users->get));
+                        ->add(
+                            new AuthMiddleware(
+                                $config->users->get,
+                                [Constants::ROLE_USERS_READ]
+                            )
+                        );
 
                         $this->get('/{user}', UsersHandler::class . ':getUser')
-                            ->add(new AuthMiddleware($config->users->get));
+                        ->add(
+                            new AuthMiddleware(
+                                $config->users->get,
+                                [Constants::ROLE_USERS_READ]
+                            )
+                        );
                     }
 
                     if ($config->users->post->enabled) {
                         $this->post('', UsersHandler::class . ':newUser')
-                            ->add(new AuthMiddleware($config->users->post));
+                        ->add(
+                            new AuthMiddleware(
+                                $config->users->post,
+                                [Constants::ROLE_USERS_CREATE]
+                            )
+                        );
                     }
 
                     if ($config->users->delete->enabled) {
                         $this->delete('/{user}', UsersHandler::class . ':deleteUser')
-                        ->add(new AuthMiddleware($config->users->delete));
+                        ->add(
+                            new AuthMiddleware(
+                                $config->users->delete,
+                                [Constants::ROLE_USERS_DELETE]
+                            )
+                        );
                     }
 
                     if ($config->users->patch->enabled) {
                         $this->patch('/{user}', UsersHandler::class . ':updateUser')
-                            ->add(new AuthMiddleware($config->users->patch));
+                        ->add(
+                            new AuthMiddleware(
+                                $config->users->patch,
+                                [Constants::ROLE_USERS_EDIT]
+                            )
+                        );
                     }
                 }
             );
@@ -134,12 +188,22 @@ class Api
                 function () use ($config) {
                     if ($config->plugins->get->enabled) {
                         $this->get('', PluginsHandler::class . ':getPlugins')
-                            ->add(new AuthMiddleware($config->plugins->get));
+                        ->add(
+                            new AuthMiddleware(
+                                $config->plugins->get,
+                                [Constants::ROLE_PLUGINS_READ]
+                            )
+                        );
                     }
 
                     if ($config->plugins->get->enabled) {
                         $this->get('/{plugin}', PluginsHandler::class . ':getPlugin')
-                            ->add(new AuthMiddleware($config->plugins->get));
+                        ->add(
+                            new AuthMiddleware(
+                                $config->plugins->get,
+                                [Constants::ROLE_PLUGINS_READ]
+                            )
+                        );
                     }
                 }
             );
@@ -150,12 +214,22 @@ class Api
 
                     if ($config->configs->get->enabled) {
                         $this->get('', ConfigHandler::class . ':getConfigs')
-                            ->add(new AuthMiddleware($config->configs->get));
+                        ->add(
+                            new AuthMiddleware(
+                                $config->configs->get,
+                                [Constants::ROLE_CONFIGS_READ]
+                            )
+                        );
                     }
 
                     if ($config->configs->get->enabled) {
                         $this->get('/{config}', ConfigHandler::class . ':getConfig')
-                            ->add(new AuthMiddleware($config->configs->get));
+                        ->add(
+                            new AuthMiddleware(
+                                $config->configs->get,
+                                [Constants::ROLE_CONFIGS_READ]
+                            )
+                        );
                     }
                 }
             );

--- a/src/Config/Constants.php
+++ b/src/Config/Constants.php
@@ -50,4 +50,40 @@ class Constants
         Constants::METHOD_POST,
         Constants::METHOD_DELETE
     ];
+
+    // Roles
+    const ROLE_SUPER = 'api.super';
+    const ROLE_PAGES_READ = 'api.pages_read';
+    const ROLE_PAGES_DELETE = 'api.pages_delete';
+    const ROLE_PAGES_EDIT = 'api.pages_edit';
+    const ROLE_PAGES_CREATE = 'api.pages_create';
+    const ROLE_USERS_READ = 'api.users_read';
+    const ROLE_USERS_DELETE = 'api.users_delete';
+    const ROLE_USERS_CREATE = 'api.users_create';
+    const ROLE_USERS_EDIT = 'api.users_edit';
+    const ROLE_PLUGINS_READ = 'api.plugins_read';
+    const ROLE_PLUGINS_EDIT = 'api.plugins_edit';
+    const ROLE_PLUGINS_INSTALL = 'api.plugins_install';
+    const ROLE_PLUGINS_UNINSTALL = 'api.plugins_uninstall';
+    const ROLE_CONFIGS_READ = 'api.configs_read';
+    const ROLE_CONFIGS_EDIT = 'api.configs_edit';
+
+    // All available methods
+    const ROLES = [
+        Constants::ROLE_SUPER,
+        Constants::ROLE_PAGES_READ,
+        Constants::ROLE_PAGES_DELETE,
+        Constants::ROLE_PAGES_EDIT,
+        Constants::ROLE_PAGES_CREATE,
+        Constants::ROLE_USERS_READ,
+        Constants::ROLE_USERS_DELETE,
+        Constants::ROLE_USERS_CREATE,
+        Constants::ROLE_USERS_EDIT,
+        Constants::ROLE_PLUGINS_READ,
+        Constants::ROLE_PLUGINS_EDIT,
+        Constants::ROLE_PLUGINS_INSTALL,
+        Constants::ROLE_PLUGINS_UNINSTALL,
+        Constants::ROLE_CONFIGS_READ,
+        Constants::ROLE_CONFIGS_EDIT
+    ];
 }

--- a/src/Config/Constants.php
+++ b/src/Config/Constants.php
@@ -68,7 +68,7 @@ class Constants
     const ROLE_CONFIGS_READ = 'api.configs_read';
     const ROLE_CONFIGS_EDIT = 'api.configs_edit';
 
-    // All available methods
+    // All available roles
     const ROLES = [
         Constants::ROLE_SUPER,
         Constants::ROLE_PAGES_READ,

--- a/src/Handlers/UsersHandler.php
+++ b/src/Handlers/UsersHandler.php
@@ -19,14 +19,14 @@ class UsersHandler extends BaseHandler
     {
         $users = [];
 
-        $files = (array) glob($this->grav['locator']->findResource("account://") . '/*.yaml');
+        $files = (array) glob($this->grav['locator']->findResource("account://") . '/*' . YAML_EXT);
 
         if (!$files) {
             return $response->withJson(Response::notFound(), 404);
         }
 
         foreach ($files as $file) {
-            $username = basename($file, '.yaml');
+            $username = basename($file, YAML_EXT);
             $users[] = $this->grav['accounts']->load($username);
         }
 
@@ -101,6 +101,10 @@ class UsersHandler extends BaseHandler
         $data['access'] = !empty($parsedBody['access'])
             ? $parsedBody['access']
             : ['site' => ['login' => true]];
+
+        $data['groups'] = isset($parsedBody['groups'])
+            ? $parsedBody['groups']
+            : [];
 
         $user = $this->createUser($username, $data);
 

--- a/src/Middlewares/AuthMiddleware.php
+++ b/src/Middlewares/AuthMiddleware.php
@@ -2,6 +2,7 @@
 namespace GravApi\Middlewares;
 
 use Grav\Common\User\User;
+use GravApi\Config\Constants;
 use GravApi\Config\Method;
 use GravApi\Responses\Response;
 
@@ -16,14 +17,24 @@ class AuthMiddleware
      */
     protected $config;
 
+    /**
+     * @var string[]
+     */
     protected $roles;
 
-    public function __construct(Method $config)
+    /**
+     * @param Method $config
+     * @param string[] $roles array of Constants::ROLES_* strings
+     */
+    public function __construct(Method $config, array $roles = array())
     {
         $this->config = $config;
 
-        // These are the default roles required for a user to use the API
-        $this->roles = ['admin.api', 'admin.super'];
+        // These are default roles which allow for a user
+        // to use any part of the API
+        $defaultRoles = ['admin.super', Constants::ROLE_SUPER];
+
+        $this->roles = array_merge($defaultRoles, $roles);
     }
 
     /**

--- a/src/Middlewares/AuthMiddleware.php
+++ b/src/Middlewares/AuthMiddleware.php
@@ -1,7 +1,7 @@
 <?php
 namespace GravApi\Middlewares;
 
-use Grav\Common\User\User;
+use Grav\Common\Grav;
 use GravApi\Config\Constants;
 use GravApi\Config\Method;
 use GravApi\Responses\Response;
@@ -29,6 +29,7 @@ class AuthMiddleware
     public function __construct(Method $config, array $roles = array())
     {
         $this->config = $config;
+        $this->grav = Grav::instance();
 
         // These are default roles which allow for a user
         // to use any part of the API
@@ -68,7 +69,7 @@ class AuthMiddleware
      */
     public function isAuthorised($username, $password)
     {
-        $user = User::load($username);
+        $user = $this->grav['accounts']->load($username);
         $isAuthenticated = $user->authenticate($password);
 
         if ($isAuthenticated) {

--- a/src/Resources/PageResource.php
+++ b/src/Resources/PageResource.php
@@ -320,7 +320,7 @@ class PageResource extends Resource
 
         return $media;
     }
-    
+
     /**
      * We process the header to return a stricter respresentation of the taxonomy (all arrays, all strings).
      *
@@ -334,11 +334,13 @@ class PageResource extends Resource
                 if (!is_array($value)) {
                     $header->taxonomy[$key] = array(is_string($value) ? $value : json_encode($value));
                 } else {
-                    $header->taxonomy[$key] = array_map(function ($e) { return is_string($e) ? $e : json_encode($e); }, $header->taxonomy[$key]);
-                } 
+                    $header->taxonomy[$key] = array_map(function ($e) {
+                        return is_string($e) ? $e : json_encode($e);
+                    }, $header->taxonomy[$key]);
+                }
             }
         }
-        
+
         return $header;
     }
 

--- a/src/Resources/UserResource.php
+++ b/src/Resources/UserResource.php
@@ -61,7 +61,8 @@ class UserResource extends Resource
             'fullname' => $this->resource->get('fullname'),
             'title' => $this->resource->get('title'),
             'state' => $this->resource->get('state'),
-            'access' => $this->resource->get('access')
+            'access' => $this->resource->get('access'),
+            'groups' => $this->resource->get('groups')
         ];
 
         if ($this->filter) {

--- a/tests/unit/Helpers/ConfigHelperTest.php
+++ b/tests/unit/Helpers/ConfigHelperTest.php
@@ -43,7 +43,8 @@ final class ConfigHelperTest extends Test
             'streams',
             'media',
             'backups',
-            'system'
+            'system',
+            'groups'
         ];
 
         $configs = ConfigHelper::loadConfigs();

--- a/tests/unit/Middlewares/AuthMiddlewareTest.php
+++ b/tests/unit/Middlewares/AuthMiddlewareTest.php
@@ -1,0 +1,175 @@
+<?php
+declare(strict_types=1);
+
+use Codeception\TestCase\Test;
+use Codeception\Util\Fixtures;
+use Slim\Http\Request;
+use Slim\Http\Response;
+use Slim\Http\Environment;
+use Grav\Common\Grav;
+use GravApi\Config\Config;
+use GravApi\Config\Constants;
+use GravApi\Middlewares\AuthMiddleware;
+
+final class AuthMiddlewareTest extends Test
+{
+    /** @var AuthMiddleware $middleware */
+    protected $middleware;
+
+    /** @var callable $next Next middleware */
+    protected $next;
+
+    protected function _before()
+    {
+        $this->middleware = new AuthMiddleware(
+            Config::instance()->users->get,
+            [Constants::ROLE_USERS_READ]
+        );
+
+        $this->next = function ($request, $response) {
+            return $response->withJson('', 200);
+        };
+    }
+
+    public function testAdminSuperRoleShouldReturnStatus200(): void
+    {
+        // User 'development' has admin super permissions
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => '/api/users',
+                'PHP_AUTH_USER' => 'development',
+                'PHP_AUTH_PW' => 'D3velopment'
+            ])
+        );
+
+        $response = $this->middleware->__invoke(
+            $request,
+            new Response(),
+            $this->next
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testSpecificRoleShouldReturnStatus200(): void
+    {
+        // User 'percy' has specific role permission
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => '/api/users',
+                'PHP_AUTH_USER' => 'percy',
+                'PHP_AUTH_PW' => 'D3velopment'
+            ])
+        );
+
+        $response = $this->middleware->__invoke(
+            $request,
+            new Response(),
+            $this->next
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testGroupInheritedRoleShouldReturnStatus200(): void
+    {
+        // User 'andy' should inherit permission from his group
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => '/api/users',
+                'PHP_AUTH_USER' => 'andy',
+                'PHP_AUTH_PW' => 'D3velopment'
+            ])
+        );
+
+        $response = $this->middleware->__invoke(
+            $request,
+            new Response(),
+            $this->next
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testNoRoleShouldReturnStatus401(): void
+    {
+        // User 'joe' does not have any API permissions
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => '/api/users',
+                'PHP_AUTH_USER' => 'joe',
+                'PHP_AUTH_PW' => 'D3velopment'
+            ])
+        );
+
+        $response = $this->middleware->__invoke(
+            $request,
+            new Response(),
+            $this->next
+        );
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    public function testNoCredentialsShouldReturnStatus401(): void
+    {
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => '/api/users'
+            ])
+        );
+
+        $response = $this->middleware->__invoke(
+            $request,
+            new Response(),
+            $this->next
+        );
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    public function testIncorrectPasswordShouldReturnStatus401(): void
+    {
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => '/api/users',
+                'PHP_AUTH_USER' => 'development',
+                'PHP_AUTH_PW' => 'incorrect'
+            ])
+        );
+
+        $response = $this->middleware->__invoke(
+            $request,
+            new Response(),
+            $this->next
+        );
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
+    public function testNonExistentUserShouldReturnStatus401(): void
+    {
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => '/api/users',
+                'PHP_AUTH_USER' => 'anonymous',
+                'PHP_AUTH_PW' => 'D3velopment'
+            ])
+        );
+
+        $response = $this->middleware->__invoke(
+            $request,
+            new Response(),
+            $this->next
+        );
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+}

--- a/tests/unit/Resources/ConfigCollectionResourceTest.php
+++ b/tests/unit/Resources/ConfigCollectionResourceTest.php
@@ -82,6 +82,6 @@ final class ConfigCollectionResourceTest extends Test
     public function testToJsonReturnsMetaCount(): void
     {
         $result = $this->resource->toJson()['meta']['count'];
-        $this->assertEquals(5, $result);
+        $this->assertEquals(6, $result);
     }
 }

--- a/tests/unit/Resources/UserResourceTest.php
+++ b/tests/unit/Resources/UserResourceTest.php
@@ -79,7 +79,8 @@ final class UserResourceTest extends Test
                 'site' => [
                     'login' => true
                 ]
-            ]
+            ],
+            'groups' => null
         ];
 
         $this->assertEquals(
@@ -149,7 +150,8 @@ final class UserResourceTest extends Test
                 'site' => [
                     'login' => true
                 ]
-            ]
+            ],
+            'groups' => null
         ];
 
         $expected = [

--- a/tests/unit/Resources/UserResourceTest.php
+++ b/tests/unit/Resources/UserResourceTest.php
@@ -172,56 +172,83 @@ final class UserResourceTest extends Test
         );
     }
 
-    // public function testToJsonReturnsAttributesOnly(): void
-    // {
-    //     $expected = [
-    //         'username' => 'development',
-    //         'email' => 'dummy@email.com',
-    //         'fullname' => 'Development',
-    //         'title' => 'Administrator',
-    //         'state' => 'enabled',
-    //         'access' => [
-    //             'admin' => [
-    //                 'login' => true,
-    //                 'super' => true
-    //             ],
-    //             'site' => [
-    //                 'login' => true
-    //             ]
-    //         ]
-    //     ];;
+    public function testToJsonReturnsAttributesOnly(): void
+    {
+        $expected = [
+            'username' => 'development',
+            'email' => 'dummy@email.com',
+            'fullname' => 'Development',
+            'title' => 'Administrator',
+            'state' => 'enabled',
+            'access' => [
+                'admin' => [
+                    'login' => true,
+                    'super' => true
+                ],
+                'site' => [
+                    'login' => true
+                ]
+            ],
+            'groups' => null
+        ];;
 
-    //     $this->assertEquals(
-    //         $expected,
-    //         $this->resource->toJson(true)
-    //     );
-    // }
+        $this->assertEquals(
+            $expected,
+            $this->resource->toJson(true)
+        );
+    }
 
-    // public function testSetFilterReturnsSpecificResourceFields(): void
-    // {
-    //     $this->_before(['email', 'title', 'state']);
+    public function testSetFilterReturnsSpecificResourceFields(): void
+    {
+        $this->_before(['email', 'title', 'state']);
 
-    //     $attributes = [
-    //         'email' => 'dummy@email.com',
-    //         'title' => 'Administrator',
-    //         'state' => 'enabled'
-    //     ];
+        $attributes = [
+            'email' => 'dummy@email.com',
+            'title' => 'Administrator',
+            'state' => 'enabled'
+        ];
 
-    //     $expected = [
-    //         'type' => Constants::TYPE_USER,
-    //         'id' => 'development',
-    //         'attributes' => $attributes,
-    //         'links' => [
-    //             'related' => [
-    //                 'self' => 'http://localhost/api/users/development',
-    //                 'resource' => 'http://localhost/api/users/'
-    //             ]
-    //         ]
-    //     ];
+        $expected = [
+            'type' => Constants::TYPE_USER,
+            'id' => 'development',
+            'attributes' => $attributes,
+            'links' => [
+                'related' => [
+                    'self' => 'http://localhost/api/users/development',
+                    'resource' => 'http://localhost/api/users/'
+                ]
+            ]
+        ];
 
-    //     $this->assertEquals(
-    //         $expected,
-    //         $this->resource->toJson()
-    //     );
-    // }
+        $this->assertEquals(
+            $expected,
+            $this->resource->toJson()
+        );
+    }
+
+    public function testCanReturnCustomUserFields(): void
+    {
+        $this->_before(['custom']);
+
+        $attributes = [
+            'custom' => 'this is a custom field'
+        ];
+
+        $expected = [
+            'type' => Constants::TYPE_USER,
+            'id' => 'development',
+            'attributes' => $attributes,
+            'links' => [
+                'related' => [
+                    'self' => 'http://localhost/api/users/development',
+                    'resource' => 'http://localhost/api/users/'
+                ]
+            ]
+        ];
+
+        $this->assertEquals(
+            $expected,
+            $this->resource->toJson()
+        );
+    }
 }


### PR DESCRIPTION
Closes #4 

Adds custom roles to allow for fine-grained access permissions per user/group per endpoint/method.