### PR TITLE
feat: allow ordering of pages

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -14,6 +14,7 @@ endpoints:
         - content
         - children
         - route
+        - order
         - slug
         - permalink
         - template

--- a/docs/specification.yaml
+++ b/docs/specification.yaml
@@ -800,6 +800,12 @@ components:
           type: string
           description: The new page's content, formatted as markdown
           example: "This is a _new_ page's content in **markdown**!"
+        order:
+          description: Set page order by specifying a number. To remove page order, set to false.
+          oneOf:
+            - type: integer
+              format: int32
+            - type: boolean
       required:
         - route
     FindPagesRequestBody:

--- a/src/Handlers/PagesHandler.php
+++ b/src/Handlers/PagesHandler.php
@@ -97,6 +97,13 @@ class PagesHandler extends BaseHandler
                 $page->content($parsedBody['content']);
             }
 
+            if (!empty($parsedBody['order'])) {
+                // Move the page we just initialised with PageHelper
+                // so that we can set the desired page order
+                $page->move($page->parent());
+                $page->order($parsedBody['order']);
+            }
+
             // Save the page with the new header/content fields
             $page->save();
         } catch (\Exception $e) {
@@ -223,6 +230,13 @@ class PagesHandler extends BaseHandler
 
             // sets the file to use our new template
             $page->name($helper->getFilename());
+        }
+
+        if (!empty($parsedBody['order'])) {
+            // We have to "move" the page, otherwise
+            // the old page order folder will remain
+            $page->move($page->parent());
+            $page->order($parsedBody['order']);
         }
 
         // save the changes to the file

--- a/src/Handlers/PagesHandler.php
+++ b/src/Handlers/PagesHandler.php
@@ -232,7 +232,8 @@ class PagesHandler extends BaseHandler
             $page->name($helper->getFilename());
         }
 
-        if (!empty($parsedBody['order'])) {
+        // We need to be able to pass `false` to remove page order
+        if (isset($parsedBody['order'])) {
             // We have to "move" the page, otherwise
             // the old page order folder will remain
             $page->move($page->parent());


### PR DESCRIPTION
Closes #21 

- [x] Enable setting page order when creating new page
- [x] Enable setting page order when updating existing page
- [x]  Test page order setting functionality
- [x] Document `order` property in API specification