### PR TITLE
feat: enable editing of any plugin config

### DIFF
--- a/docs/postman_collection.json
+++ b/docs/postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "141e3db4-9b53-4fe5-88f8-f701385aea60",
+		"_postman_id": "f5fd1ac6-f8fa-42db-a9d7-ec6bda3d9cd7",
 		"name": "Grav API Plugin",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -13,10 +13,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "localhost:8080/api/pages",
 							"host": [
@@ -36,10 +32,6 @@
 					"request": {
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "localhost:8080/api/pages/test",
 							"host": [
@@ -171,7 +163,8 @@
 					},
 					"response": []
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "Users",
@@ -196,10 +189,6 @@
 						},
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "localhost:8080/api/users",
 							"host": [
@@ -234,10 +223,6 @@
 						},
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "localhost:8080/api/pages/typography",
 							"host": [
@@ -383,7 +368,8 @@
 					},
 					"response": []
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "Plugins",
@@ -408,10 +394,6 @@
 						},
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "localhost:8080/api/plugins",
 							"host": [
@@ -446,9 +428,56 @@
 						},
 						"method": "GET",
 						"header": [],
+						"url": {
+							"raw": "localhost:8080/api/plugins/api",
+							"host": [
+								"localhost"
+							],
+							"port": "8080",
+							"path": [
+								"api",
+								"plugins",
+								"api"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update Plugin",
+					"request": {
+						"auth": {
+							"type": "basic",
+							"basic": [
+								{
+									"key": "username",
+									"value": "development",
+									"type": "string"
+								},
+								{
+									"key": "password",
+									"value": "D3velopment",
+									"type": "string"
+								}
+							]
+						},
+						"method": "PATCH",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
 						"body": {
 							"mode": "raw",
-							"raw": ""
+							"raw": "{\n\t\"custom\": \"field\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
 						},
 						"url": {
 							"raw": "localhost:8080/api/plugins/api",
@@ -465,7 +494,8 @@
 					},
 					"response": []
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "Config",
@@ -490,10 +520,6 @@
 						},
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "localhost:8080/api/configs",
 							"host": [
@@ -528,10 +554,6 @@
 						},
 						"method": "GET",
 						"header": [],
-						"body": {
-							"mode": "raw",
-							"raw": ""
-						},
 						"url": {
 							"raw": "localhost:8080/api/configs/site",
 							"host": [
@@ -547,17 +569,14 @@
 					},
 					"response": []
 				}
-			]
+			],
+			"protocolProfileBehavior": {}
 		},
 		{
 			"name": "API",
 			"request": {
 				"method": "GET",
 				"header": [],
-				"body": {
-					"mode": "raw",
-					"raw": ""
-				},
 				"url": {
 					"raw": "localhost:8080/api",
 					"host": [
@@ -571,5 +590,6 @@
 			},
 			"response": []
 		}
-	]
+	],
+	"protocolProfileBehavior": {}
 }

--- a/docs/specification.yaml
+++ b/docs/specification.yaml
@@ -48,7 +48,7 @@ paths:
         - pages
       summary: Add a new page to the site
       security:
-        - basic: ['admin.api', 'admin.super']
+        - basic: ['api.super', 'admin.super']
       description: >-
         In order to create a new page, one must **not** already exist at the specified route.
 
@@ -179,7 +179,7 @@ paths:
         - pages
       summary: Update a specific page
       security:
-        - basic: ['admin.api', 'admin.super']
+        - basic: ['api.super', 'admin.super']
       description: >-
         When passing new content via a `PATCH` request, the existing page content will be _entirely overridden_.
 
@@ -240,7 +240,7 @@ paths:
         - pages
       summary: Delete a specific page
       security:
-        - basic: ['admin.api', 'admin.super']
+        - basic: ['api.super', 'admin.super']
       description: >-
         If the deletion is successful, the API will respond with a `204` no-content status code.
 
@@ -280,7 +280,7 @@ paths:
         - users
       summary: Get all the users on the site
       security:
-        - basic: ['admin.api', 'admin.super']
+        - basic: ['api.super', 'admin.super']
       responses:
         200:
           description: Successful operation
@@ -309,7 +309,7 @@ paths:
         - users
       summary: Add a new user
       security:
-        - basic: ['admin.api', 'admin.super']
+        - basic: ['api.super', 'admin.super']
       description: >-
         There are a minimum of three required fields you must provide for the POST request to be successful. These are: `username`, `password` and `email`. If any of these are not specified, then the user will not be created. They are all expected as plain strings. Additionally, the `email` field must be a **valid email format**.
 
@@ -372,7 +372,7 @@ paths:
         - users
       summary: Get a specific user
       security:
-        - basic: ['admin.api', 'admin.super']
+        - basic: ['api.super', 'admin.super']
       parameters:
         - name: id
           in: path
@@ -411,7 +411,7 @@ paths:
         - users
       summary: Update a specific user
       security:
-        - basic: ['admin.api', 'admin.super']
+        - basic: ['api.super', 'admin.super']
       description: >-
         In order to change user information, you **must** provide a valid `password` for that user.
 
@@ -475,7 +475,7 @@ paths:
         - users
       summary: Delete a specific user
       security:
-        - basic: ['admin.api', 'admin.super']
+        - basic: ['api.super', 'admin.super']
       description: >-
         If the deletion is successful, the API will respond with a `204` no-content status code.
 
@@ -515,7 +515,7 @@ paths:
         - plugins
       summary: Get all the plugins installed on the site
       security:
-        - basic: ['admin.api', 'admin.super']
+        - basic: ['api.super', 'admin.super']
       responses:
         200:
           description: Successful operation
@@ -545,7 +545,7 @@ paths:
         - plugins
       summary: Get a specific plugin
       security:
-        - basic: ['admin.api', 'admin.super']
+        - basic: ['api.super', 'admin.super']
       parameters:
         - name: id
           in: path
@@ -579,13 +579,72 @@ paths:
               examples:
                 NotFound:
                   $ref: '#/components/examples/NotFoundResponse'
+    patch:
+      tags:
+        - plugins
+      summary: Update a specific plugin
+      description: The request's body JSON should match the config structure of the plugin which you wish to update. If you wish to remove existing properties from the config, you can set their values to `null` and they will be unset.
+      security:
+        - basic: ['api.super', 'admin.super']
+      parameters:
+        - name: id
+          in: path
+          description: The id of the plugin to update
+          required: true
+          schema:
+            type: string
+            example: "api"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                plugin_field:
+                  type: string
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PluginResponse'
+        400:
+          description: Invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                InvalidAuth:
+                  $ref: '#/components/examples/BadRequestResponse'
+        401:
+          description: Invalid authentication
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                InvalidAuth:
+                  $ref: '#/components/examples/InvalidAuthResponse'
+        404:
+          description: Plugin not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+              examples:
+                NotFound:
+                  $ref: '#/components/examples/NotFoundResponse'
   /configs:
     get:
       tags:
         - configs
       summary: Get all the site configuration files
       security:
-        - basic: ['admin.api', 'admin.super']
+        - basic: ['api.super', 'admin.super']
       responses:
         200:
           description: Successful operation
@@ -615,7 +674,7 @@ paths:
         - configs
       summary: Get a specific config file
       security:
-        - basic: ['admin.api', 'admin.super']
+        - basic: ['api.super', 'admin.super']
       parameters:
         - name: id
           in: path

--- a/grav/config/plugins/api.yaml
+++ b/grav/config/plugins/api.yaml
@@ -3,9 +3,8 @@ route: /api
 endpoints:
   /pages:
     get:
-      enabled: false
-      auth: true
-      # Only return these fields for each page
+      enabled: true
+      auth: false
       fields:
         - title
         - frontmatter
@@ -23,19 +22,18 @@ endpoints:
         - modified
         - media
     post:
-      enabled: false
+      enabled: true
       auth: true
     patch:
-      enabled: false
+      enabled: true
       auth: true
     delete:
-      enabled: false
+      enabled: true
       auth: true
   /users:
     get:
-      enabled: false
+      enabled: true
       auth: true
-      # Only return these fields for each user
       fields:
         - username
         - email
@@ -45,25 +43,24 @@ endpoints:
         - access
         - groups
     post:
-      enabled: false
+      enabled: true
       auth: true
     patch:
-      enabled: false
+      enabled: true
       auth: true
     delete:
-      enabled: false
+      enabled: true
       auth: true
   /plugins:
     get:
-      enabled: false
+      enabled: true
       auth: true
     patch:
-      enabled: false
+      enabled: true
       auth: true
   /configs:
     get:
-      enabled: false
+      enabled: true
       auth: true
-      # Prevents API from accessing these config files
       ignore_files:
         - streams

--- a/src/Api.php
+++ b/src/Api.php
@@ -205,6 +205,16 @@ class Api
                             )
                         );
                     }
+
+                    if ($config->plugins->patch->enabled) {
+                        $this->patch('/{plugin}', PluginsHandler::class . ':updatePlugin')
+                        ->add(
+                            new AuthMiddleware(
+                                $config->plugins->patch,
+                                [Constants::ROLE_PLUGINS_EDIT]
+                            )
+                        );
+                    }
                 }
             );
 

--- a/src/Helpers/PluginHelper.php
+++ b/src/Helpers/PluginHelper.php
@@ -1,0 +1,29 @@
+<?php
+namespace GravApi\Helpers;
+
+use Grav\Common\Grav;
+use Grav\Common\Plugin;
+
+/**
+ * Class PluginHelper
+ * @package GravApi\Helpers
+ */
+class PluginHelper
+{
+    /**
+     * Finds a plugin by name
+     *
+     * @param string $name
+     * @return Plugin|null
+     */
+    public static function find($name = '')
+    {
+        foreach (Grav::instance()['plugins'] as $plugin) {
+            if ($plugin->name === $name) {
+                return $plugin;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/unit/Handlers/PluginsHandlerTest.php
+++ b/tests/unit/Handlers/PluginsHandlerTest.php
@@ -85,4 +85,78 @@ final class PluginsHandlerTest extends Test
 
         $this->assertEquals(404, $response->getStatusCode());
     }
+
+    public function testUpdatePluginShouldReturnStatus200(): void
+    {
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'PATCH',
+                'REQUEST_URI' => '/api/plugins/api'
+            ])
+        )->withParsedBody([
+            'custom' => 'field'
+        ]);
+
+        $response = $this->handler->updatePlugin(
+            $request,
+            $this->response,
+            [
+                'plugin' => 'api'
+            ]
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $data = json_decode($response->getBody()->__toString());
+        $this->assertEquals('field', $data->attributes->custom);
+        // Should not manipulate existing fields
+        $this->assertEquals('/api', $data->attributes->route);
+    }
+
+    public function testUpdatePluginShouldReturnStatus404(): void
+    {
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'PATCH',
+                'REQUEST_URI' => '/api/plugins/blarg'
+            ])
+        )->withParsedBody([
+            'custom' => 'field'
+        ]);
+
+        $response = $this->handler->updatePlugin(
+            $request,
+            $this->response,
+            [
+                'plugin' => 'blarg'
+            ]
+        );
+
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+
+    public function testUpdatePluginShouldRemoveNullProperties(): void
+    {
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'PATCH',
+                'REQUEST_URI' => '/api/plugins/api'
+            ])
+        )->withParsedBody([
+            'custom' => null
+        ]);
+
+        $response = $this->handler->updatePlugin(
+            $request,
+            $this->response,
+            [
+                'plugin' => 'api'
+            ]
+        );
+
+        $data = json_decode($response->getBody()->__toString());
+        $this->assertFalse(property_exists($data->attributes, 'custom'));
+    }
+
+    // TODO: add test to check updatePlugin for 400 once blueprints defined with validation settings
 }

--- a/tests/unit/Helpers/PluginHelperTest.php
+++ b/tests/unit/Helpers/PluginHelperTest.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+use Codeception\TestCase\Test;
+use Codeception\Util\Fixtures;
+use Grav\Common\Grav;
+use GravApi\Helpers\PluginHelper;
+use Grav\Common\Plugin;
+
+final class PluginHelperTest extends Test
+{
+    /** @var Grav $client */
+    protected $grav;
+
+    protected function _before()
+    {
+        $grav = Fixtures::get('grav');
+        $this->grav = $grav();
+    }
+
+    public function testFindShouldReturnAPluginClass(): void
+    {
+        $this->assertInstanceOf(Plugin::class, PluginHelper::find('api'));
+    }
+
+    public function testFindShouldReturnNullWhenMissingPlugin(): void
+    {
+        $this->assertNull(PluginHelper::find('missing_plugin'));
+    }
+}

--- a/tests/unit/Resources/UserResourceTest.php
+++ b/tests/unit/Resources/UserResourceTest.php
@@ -190,7 +190,7 @@ final class UserResourceTest extends Test
                 ]
             ],
             'groups' => null
-        ];;
+        ];
 
         $this->assertEquals(
             $expected,


### PR DESCRIPTION
Closes #22

- [x] Create `PluginHandler` class to simplify finding plugin 
- [x] Create new `PATCH /api/plugins/{id}` endpoint 
- [x] Create handler for updating plugin config
- [x] Adjust plugin config to disable all endpoints by default and add user override config
- [x] Write tests to cover new functionality
- [x] Document new endpoint in API specification
- [x] Update postman collection
