### PR TITLE
feat: enable taxonomy based permissions

### DIFF
--- a/grav/accounts/tom.yaml
+++ b/grav/accounts/tom.yaml
@@ -4,7 +4,7 @@ title: Permissions Tester
 state: enabled
 access:
   api:
-    taxonomy___category___blog: true
+    taxonomy_category___blog: true
   admin:
     super: false
     login: true

--- a/grav/accounts/tom.yaml
+++ b/grav/accounts/tom.yaml
@@ -1,14 +1,13 @@
-email: dummy@email.com
-fullname: Development
-title: Administrator
+email: tom@email.com
+fullname: Taxonomy Tom
+title: Permissions Tester
 state: enabled
-custom: this is a custom field
 access:
   api:
-    super: true
+    taxonomy_category_blog: true
   admin:
+    super: false
     login: true
-    super: true
   site:
     login: true
 hashed_password: $2y$10$aIw9wIWgj6bVuOk.sGRgw.TSZFOkIFmteDOLUFNj5Uka4ugxp5cTu

--- a/grav/accounts/tom.yaml
+++ b/grav/accounts/tom.yaml
@@ -4,7 +4,7 @@ title: Permissions Tester
 state: enabled
 access:
   api:
-    taxonomy_category_blog: true
+    taxonomy___category___blog: true
   admin:
     super: false
     login: true

--- a/grav/config/groups.yaml
+++ b/grav/config/groups.yaml
@@ -14,6 +14,7 @@ siteadmin:
       plugins_uninstall: true
       configs_read: true
       configs_edit: true
+      taxonomy_category_blog: true
     admin:
       login: true
     site:

--- a/grav/config/site.yaml
+++ b/grav/config/site.yaml
@@ -4,4 +4,4 @@ author:
   email: 'joe@example.com'
 metadata:
     description: 'Grav is an easy to use, yet powerful, open source flat-file CMS'
-taxonomies: [taxonomyKey1,taxonomyKey2]
+taxonomies: [category, tag]

--- a/grav/pages/othertest/default.md
+++ b/grav/pages/othertest/default.md
@@ -1,7 +1,7 @@
 ---
 title: 'Other test page'
 taxonomy:
-  taxonomyKey1: taxonomyValue1
+  category: blog
 ---
 
 # Hello! This is a test.

--- a/grav/pages/test/default.md
+++ b/grav/pages/test/default.md
@@ -2,8 +2,8 @@
 title: 'Test page'
 custom_field: WORLD
 taxonomy:
-  taxonomyKey1: taxonomyValue1
-  taxonomyKey2: [taxonomyValue2, taxonomyValue3]
+  category: blog
+  tag: [news, grav]
 ---
 
 # Hello {{custom_field}}! This is a test.

--- a/src/Api.php
+++ b/src/Api.php
@@ -135,7 +135,11 @@ class Api
                         ->add(
                             new AuthMiddleware(
                                 $config->pages->patch,
-                                [Constants::ROLE_PAGES_EDIT]
+                                array_merge(
+                                    [Constants::ROLE_PAGES_EDIT],
+                                    // We allow all taxonomy roles through and will authorise in handler
+                                    TaxonomyHelper::getRoles()
+                                )
                             )
                         );
                     }

--- a/src/Api.php
+++ b/src/Api.php
@@ -74,7 +74,11 @@ class Api
                         ->add(
                             new AuthMiddleware(
                                 $config->pages->get,
-                                [Constants::ROLE_PAGES_READ]
+                                array_merge(
+                                    [Constants::ROLE_PAGES_READ],
+                                    // We allow all taxonomy roles and will filter collection in handler
+                                    TaxonomyHelper::getRoles()
+                                )
                             )
                         );
 

--- a/src/Api.php
+++ b/src/Api.php
@@ -121,7 +121,11 @@ class Api
                         ->add(
                             new AuthMiddleware(
                                 $config->pages->delete,
-                                [Constants::ROLE_PAGES_DELETE]
+                                array_merge(
+                                    [Constants::ROLE_PAGES_DELETE],
+                                    // We allow all taxonomy roles through and will authorise in handler
+                                    TaxonomyHelper::getRoles()
+                                )
                             )
                         );
                     }

--- a/src/Api.php
+++ b/src/Api.php
@@ -10,6 +10,7 @@ use GravApi\Handlers\PagesHandler;
 use GravApi\Handlers\PluginsHandler;
 use GravApi\Handlers\UsersHandler;
 use GravApi\Config\Constants;
+use GravApi\Helpers\TaxonomyHelper;
 
 /**
  * Class Api
@@ -81,7 +82,11 @@ class Api
                         ->add(
                             new AuthMiddleware(
                                 $config->pages->get,
-                                [Constants::ROLE_PAGES_READ]
+                                array_merge(
+                                    [Constants::ROLE_PAGES_READ],
+                                    // We allow all taxonomy roles through and will authorise in handler
+                                    TaxonomyHelper::getRoles()
+                                )
                             )
                         );
                     }

--- a/src/Handlers/PagesHandler.php
+++ b/src/Handlers/PagesHandler.php
@@ -42,7 +42,7 @@ class PagesHandler extends BaseHandler
 
         // If auth is enabled, we need to check if user has
         // one of the custom taxonomy roles
-        if (Config::instance()->pages->get->auth) {
+        if (Config::instance()->pages->get->useAuth) {
             $user = $request->getAttribute('user');
 
             // Compare user's access roles against the available

--- a/src/Handlers/PagesHandler.php
+++ b/src/Handlers/PagesHandler.php
@@ -250,6 +250,24 @@ class PagesHandler extends BaseHandler
             return $response->withJson(Response::notFound(), 404);
         }
 
+        // If auth is enabled, we need to check if user has
+        // one of the custom taxonomy roles
+        if (Config::instance()->pages->patch->useAuth) {
+            $user = $request->getAttribute('user');
+
+            // Compare user's access roles against the available
+            // taxonomy roles for the page. User might also have a
+            // generic edit role, so we need to check again for that.
+            $hasRole = AuthHelper::checkRoles($user, array_merge(
+                [Constants::ROLE_PAGES_EDIT],
+                TaxonomyHelper::getPageRoles($page)
+            ));
+
+            if (!$hasRole) {
+                return $response->withJson(Response::unauthorized(), 401);
+            }
+        }
+
         $parsedBody = $request->getParsedBody();
 
         $template = isset($parsedBody['template'])

--- a/src/Helpers/AuthHelper.php
+++ b/src/Helpers/AuthHelper.php
@@ -2,6 +2,7 @@
 namespace GravApi\Helpers;
 
 use Grav\Common\User;
+use GravApi\Config\Constants;
 
 /**
  * Class AuthHelper
@@ -18,7 +19,14 @@ class AuthHelper
      */
     public static function checkRoles($user, $roles)
     {
-        foreach ($roles as $role) {
+        if (!$user) {
+            return false;
+        }
+
+        // By default, the super role will always be allowed
+        $allRoles = array_merge([Constants::ROLE_SUPER], $roles);
+
+        foreach ($allRoles as $role) {
             if ($user->authorize($role)) {
                 return true;
             }

--- a/src/Helpers/AuthHelper.php
+++ b/src/Helpers/AuthHelper.php
@@ -1,0 +1,29 @@
+<?php
+namespace GravApi\Helpers;
+
+use Grav\Common\User;
+
+/**
+ * Class AuthHelper
+ * @package GravApi\Helpers
+ */
+class AuthHelper
+{
+    /**
+     * Checks whether a user has any of the required roles
+     *
+     * @param User $user
+     * @param string[] $roles
+     * @return bool
+     */
+    public static function checkRoles($user, $roles)
+    {
+        foreach ($roles as $role) {
+            if ($user->authorize($role)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Helpers/TaxonomyHelper.php
+++ b/src/Helpers/TaxonomyHelper.php
@@ -2,6 +2,7 @@
 namespace GravApi\Helpers;
 
 use Grav\Common\Grav;
+use Grav\Common\User;
 
 /**
  * Class TaxonomyHelper
@@ -59,5 +60,26 @@ class TaxonomyHelper
         }
 
         return $roles;
+    }
+
+    /**
+    * Gets all taxonomy access roles posssessed by a user
+    *
+    * @param User $user
+    * @return array $taxonomies
+    */
+    public static function getUserRolesAsTaxonomy($user)
+    {
+        $taxonomies = [];
+
+        $roles = $user->get('access.api');
+
+        foreach ($roles as $name => $value) {
+            if (preg_match('/^taxonomy___(.*)___(.*)/', $name, $matches)) {
+                $taxonomies[$matches[1]][] = $matches[2];
+            }
+        }
+
+        return $taxonomies;
     }
 }

--- a/src/Helpers/TaxonomyHelper.php
+++ b/src/Helpers/TaxonomyHelper.php
@@ -38,11 +38,7 @@ class TaxonomyHelper
      */
     public function formatAsRole($name, $value)
     {
-        return sprintf(
-            'api.taxonomy_%s_%s',
-            strtolower(preg_replace('/\s+/', '_', $name)),
-            strtolower(preg_replace('/\s+/', '_', $value))
-        );
+        return sprintf('api.taxonomy___%s___%s', $name, $value);
     }
 
     /**

--- a/src/Helpers/TaxonomyHelper.php
+++ b/src/Helpers/TaxonomyHelper.php
@@ -1,0 +1,63 @@
+<?php
+namespace GravApi\Helpers;
+
+use Grav\Common\Grav;
+
+/**
+ * Class TaxonomyHelper
+ * @package GravApi\Helpers
+ */
+class TaxonomyHelper
+{
+    /**
+     * Returns all possible taxonomy access roles based on
+     * actual site taxonomy data
+     *
+     * @return string[]
+     */
+    public static function getRoles()
+    {
+        $roles = [];
+        $taxonomies = Grav::instance()['taxonomy']->taxonomy();
+
+        foreach ($taxonomies as $name => $value) {
+            foreach ($value as $key => $v) {
+                $roles[] = self::formatAsRole($name, $key);
+            }
+        }
+
+        return $roles;
+    }
+
+    /**
+     * Formats a taxonomy as an access role string
+     *
+     * @param string $name The name of the taxonomy
+     * @param string $value The value of the taxonomy
+     * @return string role
+     */
+    public function formatAsRole($name, $value)
+    {
+        return sprintf('api.taxonomy_%s_%s', $name, $value);
+    }
+
+    /**
+     * Gets all access roles based on a single page's
+     * taxonomy data
+     *
+     * @param Page $page
+     * @return string[] $roles
+     */
+    public static function getPageRoles($page)
+    {
+        $roles = [];
+
+        foreach ($page->taxonomy() as $name => $value) {
+            foreach ($value as $v) {
+                $roles[] = self::formatAsRole($name, $v);
+            }
+        }
+
+        return $roles;
+    }
+}

--- a/src/Helpers/TaxonomyHelper.php
+++ b/src/Helpers/TaxonomyHelper.php
@@ -38,7 +38,11 @@ class TaxonomyHelper
      */
     public function formatAsRole($name, $value)
     {
-        return sprintf('api.taxonomy_%s_%s', $name, $value);
+        return sprintf(
+            'api.taxonomy_%s_%s',
+            strtolower(preg_replace('/\s+/', '_', $name)),
+            strtolower(preg_replace('/\s+/', '_', $value))
+        );
     }
 
     /**

--- a/src/Helpers/TaxonomyHelper.php
+++ b/src/Helpers/TaxonomyHelper.php
@@ -39,7 +39,7 @@ class TaxonomyHelper
      */
     public function formatAsRole($name, $value)
     {
-        return sprintf('api.taxonomy___%s___%s', $name, $value);
+        return sprintf('api.taxonomy_%s___%s', $name, $value);
     }
 
     /**
@@ -75,7 +75,7 @@ class TaxonomyHelper
         $roles = $user->get('access.api');
 
         foreach ($roles as $name => $value) {
-            if (preg_match('/^taxonomy___(.*)___(.*)/', $name, $matches)) {
+            if (preg_match('/^taxonomy_(.*)___(.*)/', $name, $matches)) {
                 $taxonomies[$matches[1]][] = $matches[2];
             }
         }

--- a/src/Middlewares/AuthMiddleware.php
+++ b/src/Middlewares/AuthMiddleware.php
@@ -2,7 +2,6 @@
 namespace GravApi\Middlewares;
 
 use Grav\Common\Grav;
-use GravApi\Config\Constants;
 use GravApi\Config\Method;
 use GravApi\Helpers\AuthHelper;
 use GravApi\Responses\Response;
@@ -31,12 +30,7 @@ class AuthMiddleware
     {
         $this->config = $config;
         $this->grav = Grav::instance();
-
-        // These are default roles which allow for a user
-        // to use any part of the API
-        $defaultRoles = ['admin.super', Constants::ROLE_SUPER];
-
-        $this->roles = array_merge($defaultRoles, $roles);
+        $this->roles = $roles;
     }
 
     /**

--- a/src/Middlewares/AuthMiddleware.php
+++ b/src/Middlewares/AuthMiddleware.php
@@ -34,11 +34,11 @@ class AuthMiddleware
     }
 
     /**
-     * @param  \Psr\Http\Message\ServerRequestInterface $request  PSR7 request
-     * @param  \Psr\Http\Message\ResponseInterface      $response PSR7 response
-     * @param  callable                                 $next     Next middleware
+     * @param  \Slim\Http\Request $request  PSR7 request
+     * @param  \Slim\Http\Response $response PSR7 response
+     * @param  callable $next Next middleware
      *
-     * @return \Psr\Http\Message\ResponseInterface
+     * @return \Slim\Http\Response
      */
     public function __invoke($request, $response, $next)
     {

--- a/tests/unit/Handlers/PagesHandlerTest.php
+++ b/tests/unit/Handlers/PagesHandlerTest.php
@@ -98,8 +98,8 @@ final class PagesHandlerTest extends Test
             ])
         )->withParsedBody([
             'taxonomyFilter' => [
-                'taxonomyKey1' => ['taxonomyValue1'],
-                'taxonomyKey2' => ['taxonomyValue2', 'taxonomyValue3']
+                'category' => ['blog'],
+                'tag' => ['news', 'grav']
             ],
             'operation' => 'and'
         ]);
@@ -118,7 +118,7 @@ final class PagesHandlerTest extends Test
             ])
         )->withParsedBody([
             'taxonomyFilter' => [
-                'taxonomyKey1' => ['taxonomyValue1']
+                'category' => ['blog']
             ],
             'operation' => 'and'
         ]);
@@ -137,7 +137,7 @@ final class PagesHandlerTest extends Test
             ])
         )->withParsedBody([
             'taxonomyFilter' => [
-                'taxonomyKey2' => ['taxonomyValue2']
+                'tag' => ['news']
             ],
             'operation' => 'or'
         ]);

--- a/tests/unit/Handlers/PagesHandlerTest.php
+++ b/tests/unit/Handlers/PagesHandlerTest.php
@@ -33,6 +33,7 @@ final class PagesHandlerTest extends Test
                 Constants::ENDPOINT_PAGE => [
                     Constants::METHOD_GET => [
                         'enabled' => true,
+                        'auth' => false,
                         'fields' => $attributeFields
                     ]
                 ]

--- a/tests/unit/Handlers/PagesHandlerTest.php
+++ b/tests/unit/Handlers/PagesHandlerTest.php
@@ -35,6 +35,14 @@ final class PagesHandlerTest extends Test
                         'enabled' => true,
                         'auth' => false,
                         'fields' => $attributeFields
+                    ],
+                    Constants::METHOD_PATCH => [
+                        'enabled' => true,
+                        'auth' => false
+                    ],
+                    Constants::METHOD_DELETE => [
+                        'enabled' => true,
+                        'auth' => false
                     ]
                 ]
             ]

--- a/tests/unit/Resources/PageResourceTest.php
+++ b/tests/unit/Resources/PageResourceTest.php
@@ -91,10 +91,10 @@ final class PageResourceTest extends Test
                 "title" => "Test page",
                 "custom_field" => "WORLD",
                 "taxonomy" => [
-                    "taxonomyKey1" => "taxonomyValue1",
-                    "taxonomyKey2" => [
-                        "taxonomyValue2",
-                        "taxonomyValue3"
+                    "category" => "blog",
+                    "tag" => [
+                        "news",
+                        "grav"
                     ]
                 ]
             ],
@@ -130,7 +130,7 @@ final class PageResourceTest extends Test
             "permalink" => "http://localhost/test",
             "publishDate" => null,
             "published" => true,
-            "raw" => "---\ntitle: 'Test page'\ncustom_field: WORLD\ntaxonomy:\n  taxonomyKey1: taxonomyValue1\n  taxonomyKey2: [taxonomyValue2, taxonomyValue3]\n---\n\n# Hello {{custom_field}}! This is a test.\n",
+            "raw" => "---\ntitle: 'Test page'\ncustom_field: WORLD\ntaxonomy:\n  category: blog\n  tag: [news, grav]\n---\n\n# Hello {{custom_field}}! This is a test.\n",
             "rawMarkdown" => "# Hello {{custom_field}}! This is a test.\n",
             "rawRoute" => "/test",
             "root" => false,
@@ -140,12 +140,12 @@ final class PageResourceTest extends Test
             "slug" => "test",
             "summary" => "<h1>Hello {{custom_field}}! This is a test.</h1>",
             "taxonomy" => [
-                "taxonomyKey1" => [
-                    "taxonomyValue1"
+                "category" => [
+                    "blog"
                 ],
-                "taxonomyKey2" => [
-                    "taxonomyValue2",
-                    "taxonomyValue3"
+                "tag" => [
+                    "news",
+                    "grav"
                 ]
             ],
             "template" => "default",

--- a/tests/unit/Resources/UserResourceTest.php
+++ b/tests/unit/Resources/UserResourceTest.php
@@ -78,6 +78,9 @@ final class UserResourceTest extends Test
                 ],
                 'site' => [
                     'login' => true
+                ],
+                'api' => [
+                    'super' => true
                 ]
             ],
             'groups' => null
@@ -149,6 +152,9 @@ final class UserResourceTest extends Test
                 ],
                 'site' => [
                     'login' => true
+                ],
+                'api' => [
+                    'super' => true
                 ]
             ],
             'groups' => null
@@ -187,6 +193,9 @@ final class UserResourceTest extends Test
                 ],
                 'site' => [
                     'login' => true
+                ],
+                'api' => [
+                    'super' => true
                 ]
             ],
             'groups' => null


### PR DESCRIPTION
Closes #58 

Enables taxonomy based permissions by generating custom access roles from the Grav site's taxonomy data. When a user has a taxonomy role, they'll be able to read/edit/delete pages with that taxonomy value (but not "generic" pages if they do not have the "standard" roles, such as `api.pages_read`).

- [x] Create `TaxonomyHelper` to generate custom roles
- [x] Create `AuthHelper` to check roles of user
- [x] Refactor `AuthMiddleware` to use new helper class
- [x] Register new taxonomy permissions with the admin plugin
- [x] Add mock data to development site
- [x] Convert taxonomy values to snake_case in `TaxonomyHelper::formatAsRole()`
- [x] Enable taxonomy roles for `getPage`
- [x] Enable taxonomy roles for `getPages`
- [x] Enable taxonomy roles for `deletePage`
- [x] Enable taxonomy roles for `updatePage`
- [ ] Add tests to cover new functionality