### PR TITLE
feat: create advanced access permissions for pages resource

### DIFF
--- a/api.php
+++ b/api.php
@@ -14,6 +14,11 @@ class ApiPlugin extends Plugin
     protected $defaultBaseRoute = 'api';
     protected $api;
 
+    // This will enable the plugin to extend the user/account blueprint
+    public $features = [
+        'blueprints' => 1000,
+    ];
+
     /**
      * @return array
      *

--- a/blueprints/user/account.yaml
+++ b/blueprints/user/account.yaml
@@ -27,7 +27,7 @@ form:
               label: PLUGIN_ADMIN.TAXONOMY
               # HACKY WORKAROUND TO POPULATE FIELD WITH USER DATA
               data-default@:
-                - '\GravApi\Helpers\TaxonomyHelper::getUserTaxonomy'
+                - '\GravApi\Helpers\BlueprintHelper::getUserTaxonomy'
                 - 'get'
               multiple: true
               validate:
@@ -50,7 +50,7 @@ form:
               label: PLUGIN_ADMIN.TAXONOMY
               # HACKY WORKAROUND TO POPULATE FIELD WITH USER DATA
               data-default@:
-                - '\GravApi\Helpers\TaxonomyHelper::getUserTaxonomy'
+                - '\GravApi\Helpers\BlueprintHelper::getUserTaxonomy'
                 - 'patch'
               multiple: true
               validate:
@@ -86,7 +86,7 @@ form:
               label: PLUGIN_ADMIN.TAXONOMY
               # HACKY WORKAROUND TO POPULATE FIELD WITH USER DATA
               data-default@:
-                - '\GravApi\Helpers\TaxonomyHelper::getUserTaxonomy'
+                - '\GravApi\Helpers\BlueprintHelper::getUserTaxonomy'
                 - 'delete'
               multiple: true
               validate:

--- a/blueprints/user/account.yaml
+++ b/blueprints/user/account.yaml
@@ -1,0 +1,93 @@
+extends@: parent@
+
+form:
+  fields:
+    api_advanced_access:
+      security@: admin.super
+      title: API Advanced Access
+      text: This section allows for advanced customisation of the user's page permissions. In order for this to take effect, you MUST also enable the `api.pages_advanced_access` role. Note that these permissions only apply to access via the API, not general page access on the site frontend.
+      type: section
+      underline: true
+      fields:
+        get:
+          type: fieldset
+          security@: admin.super
+          title: GET - Read Pages
+          text: Configure which pages the user is able to read via the API.
+          collapsed: true
+          collapsible: true
+          fields:
+            api.advanced_access.pages.get.routes:
+              type: array
+              label: Routes
+              help: A route such as `/page` will enable access to *only* that page, and `/page/*` will allow access to *any* descendant of `/page` but NOT `/page` itself.
+              value_only: true
+            api.advanced_access.pages.get.taxonomy:
+              type: taxonomy
+              label: PLUGIN_ADMIN.TAXONOMY
+              # HACKY WORKAROUND TO POPULATE FIELD WITH USER DATA
+              data-default@:
+                - '\GravApi\Helpers\TaxonomyHelper::getUserTaxonomy'
+                - 'get'
+              multiple: true
+              validate:
+                type: array
+        patch:
+          type: fieldset
+          security@: admin.super
+          title: PATCH - Edit Pages
+          text: Configure which pages the user is able to edit via the API.
+          collapsed: true
+          collapsible: true
+          fields:
+            api.advanced_access.pages.patch.routes:
+              type: array
+              label: Routes
+              help: A route such as `/page` will enable access to *only* that page, and `/page/*` will allow access to *any* descendant of `/page` but NOT `/page` itself.
+              value_only: true
+            api.advanced_access.pages.patch.taxonomy:
+              type: taxonomy
+              label: PLUGIN_ADMIN.TAXONOMY
+              # HACKY WORKAROUND TO POPULATE FIELD WITH USER DATA
+              data-default@:
+                - '\GravApi\Helpers\TaxonomyHelper::getUserTaxonomy'
+                - 'patch'
+              multiple: true
+              validate:
+                type: array
+        post:
+          type: fieldset
+          security@: admin.super
+          title: POST - Create Pages
+          text: Configure which pages the user is able to create via the API.
+          collapsed: true
+          collapsible: true
+          fields:
+            api.advanced_access.pages.post.routes:
+              type: array
+              label: Routes
+              help: A route such as `/page` will enable access to *only* that page, and `/page/*` will allow access to *any* descendant of `/page` but NOT `/page` itself.
+              value_only: true
+        delete:
+          type: fieldset
+          security@: admin.super
+          title: DELETE - Remove Pages
+          text: Configure which pages the user is able to delete via the API.
+          collapsed: true
+          collapsible: true
+          fields:
+            api.advanced_access.pages.delete.routes:
+              type: array
+              label: Routes
+              help: A route such as `/page` will enable access to *only* that page, and `/page/*` will allow access to *any* descendant of `/page` but NOT `/page` itself.
+              value_only: true
+            api.advanced_access.pages.delete.taxonomy:
+              type: taxonomy
+              label: PLUGIN_ADMIN.TAXONOMY
+              # HACKY WORKAROUND TO POPULATE FIELD WITH USER DATA
+              data-default@:
+                - '\GravApi\Helpers\TaxonomyHelper::getUserTaxonomy'
+                - 'delete'
+              multiple: true
+              validate:
+                type: array

--- a/codeception.yml
+++ b/codeception.yml
@@ -8,7 +8,7 @@ paths:
 settings:
     bootstrap: _bootstrap.php
     colors: true
-    memory_limit: 1024M
+    memory_limit: 2048M
 extensions:
     enabled:
         - Codeception\Extension\RunFailed

--- a/grav/accounts/development.yaml
+++ b/grav/accounts/development.yaml
@@ -4,6 +4,8 @@ title: Administrator
 state: enabled
 custom: this is a custom field
 access:
+  api:
+    super: true
   admin:
     login: true
     super: true

--- a/grav/accounts/greg.yaml
+++ b/grav/accounts/greg.yaml
@@ -3,5 +3,5 @@ fullname: Groupie Greg
 title: Permissions Tester
 state: enabled
 groups:
-  - blogger
+  - bloggers
 hashed_password: $2y$10$aIw9wIWgj6bVuOk.sGRgw.TSZFOkIFmteDOLUFNj5Uka4ugxp5cTu

--- a/grav/accounts/greg.yaml
+++ b/grav/accounts/greg.yaml
@@ -1,0 +1,7 @@
+email: greg@email.com
+fullname: Groupie Greg
+title: Permissions Tester
+state: enabled
+groups:
+  - blogger
+hashed_password: $2y$10$aIw9wIWgj6bVuOk.sGRgw.TSZFOkIFmteDOLUFNj5Uka4ugxp5cTu

--- a/grav/accounts/tom.yaml
+++ b/grav/accounts/tom.yaml
@@ -1,0 +1,32 @@
+email: tom@email.com
+fullname: Taxonomy Tom
+title: Permissions Tester
+state: enabled
+access:
+  api:
+    pages_advanced_access: true
+  admin:
+    super: false
+    login: true
+  site:
+    login: true
+api:
+  advanced_access:
+    pages:
+      get:
+        routes:
+          - /typography
+        taxonomy:
+          category:
+            - blog
+      patch:
+        taxonomy:
+          category:
+            - blog
+      delete:
+        routes:
+          - /test
+        taxonomy:
+          category:
+            - blog
+hashed_password: $2y$10$aIw9wIWgj6bVuOk.sGRgw.TSZFOkIFmteDOLUFNj5Uka4ugxp5cTu

--- a/grav/accounts/tom.yaml
+++ b/grav/accounts/tom.yaml
@@ -16,9 +16,15 @@ api:
       get:
         routes:
           - /typography
+          - /test/*
         taxonomy:
           category:
-            - blog
+            - news
+          tag:
+            - grav
+      post:
+        routes:
+          - /test/*
       patch:
         taxonomy:
           category:

--- a/grav/accounts/tom.yaml
+++ b/grav/accounts/tom.yaml
@@ -31,7 +31,7 @@ api:
             - blog
       delete:
         routes:
-          - /test
+          - /test/*
         taxonomy:
           category:
             - blog

--- a/grav/config/groups.yaml
+++ b/grav/config/groups.yaml
@@ -47,3 +47,20 @@ bloggers:
           taxonomy:
             category:
               - blog
+testers:
+  readableName: Testers
+  description: 'The group of route /test'
+  icon: child
+  access:
+    api:
+      pages_advanced_access: true
+    admin:
+      login: true
+    site:
+      login: true
+  api:
+    advanced_access:
+      pages:
+        get:
+          routes:
+            - /test

--- a/grav/config/groups.yaml
+++ b/grav/config/groups.yaml
@@ -18,3 +18,32 @@ siteadmin:
       login: true
     site:
       login: true
+bloggers:
+  readableName: Bloggers
+  description: 'The group of blog authors'
+  icon: child
+  access:
+    api:
+      pages_advanced_access: true
+    admin:
+      login: true
+    site:
+      login: true
+  api:
+    advanced_access:
+      pages:
+        get:
+          taxonomy:
+            category:
+              - blog
+        patch:
+          taxonomy:
+            category:
+              - blog
+        post:
+          routes:
+            - /blog/*
+        delete:
+          taxonomy:
+            category:
+              - blog

--- a/grav/config/site.yaml
+++ b/grav/config/site.yaml
@@ -4,4 +4,4 @@ author:
   email: 'joe@example.com'
 metadata:
     description: 'Grav is an easy to use, yet powerful, open source flat-file CMS'
-taxonomies: [taxonomyKey1,taxonomyKey2]
+taxonomies: [category, tag]

--- a/grav/pages/othertest/default.md
+++ b/grav/pages/othertest/default.md
@@ -1,7 +1,7 @@
 ---
 title: 'Other test page'
 taxonomy:
-  taxonomyKey1: taxonomyValue1
+    category: blog
 ---
 
 # Hello! This is a test.

--- a/grav/pages/test/default.md
+++ b/grav/pages/test/default.md
@@ -2,8 +2,8 @@
 title: 'Test page'
 custom_field: WORLD
 taxonomy:
-  taxonomyKey1: taxonomyValue1
-  taxonomyKey2: [taxonomyValue2, taxonomyValue3]
+    category: blog
+    tag: [news, grav]
 ---
 
 # Hello {{custom_field}}! This is a test.

--- a/src/Api.php
+++ b/src/Api.php
@@ -110,10 +110,10 @@ class Api
                     if ($config->pages->delete->enabled) {
                         $this->delete('/{page:.*}', PagesHandler::class . ':deletePage')
                         ->add(
-                            new AuthMiddleware(
-                                $config->pages->delete,
-                                [Constants::ROLE_PAGES_DELETE]
-                            )
+                            new AuthMiddleware($config->pages->delete, [
+                                Constants::ROLE_PAGES_DELETE,
+                                Constants::ROLE_PAGES_ADVANCED
+                            ])
                         );
                     }
 

--- a/src/Api.php
+++ b/src/Api.php
@@ -79,10 +79,10 @@ class Api
 
                         $this->get('/{page:.*}', PagesHandler::class . ':getPage')
                         ->add(
-                            new AuthMiddleware(
-                                $config->pages->get,
-                                [Constants::ROLE_PAGES_READ]
-                            )
+                            new AuthMiddleware($config->pages->get, [
+                                Constants::ROLE_PAGES_READ,
+                                Constants::ROLE_PAGES_ADVANCED
+                            ])
                         );
                     }
 

--- a/src/Api.php
+++ b/src/Api.php
@@ -120,10 +120,10 @@ class Api
                     if ($config->pages->patch->enabled) {
                         $this->patch('/{page:.*}', PagesHandler::class . ':updatePage')
                         ->add(
-                            new AuthMiddleware(
-                                $config->pages->patch,
-                                [Constants::ROLE_PAGES_EDIT]
-                            )
+                            new AuthMiddleware($config->pages->patch, [
+                                Constants::ROLE_PAGES_EDIT,
+                                Constants::ROLE_PAGES_ADVANCED
+                            ])
                         );
                     }
                 }

--- a/src/Api.php
+++ b/src/Api.php
@@ -71,10 +71,10 @@ class Api
                     if ($config->pages->get->enabled) {
                         $this->get('', PagesHandler::class . ':getPages')
                         ->add(
-                            new AuthMiddleware(
-                                $config->pages->get,
-                                [Constants::ROLE_PAGES_READ]
-                            )
+                            new AuthMiddleware($config->pages->get, [
+                                Constants::ROLE_PAGES_READ,
+                                Constants::ROLE_PAGES_ADVANCED
+                            ])
                         );
 
                         $this->get('/{page:.*}', PagesHandler::class . ':getPage')

--- a/src/Api.php
+++ b/src/Api.php
@@ -100,10 +100,10 @@ class Api
                     if ($config->pages->post->enabled) {
                         $this->post('', PagesHandler::class . ':newPage')
                         ->add(
-                            new AuthMiddleware(
-                                $config->pages->post,
-                                [Constants::ROLE_PAGES_CREATE]
-                            )
+                            new AuthMiddleware($config->pages->post, [
+                                Constants::ROLE_PAGES_CREATE,
+                                Constants::ROLE_PAGES_ADVANCED
+                            ])
                         );
                     }
 

--- a/src/Config/Constants.php
+++ b/src/Config/Constants.php
@@ -94,5 +94,5 @@ class Constants
     /**
      * Pattern for route matching which will allow "any descendents"
      */
-    const REGEX_DESCENDENT_WILDCARD = '/\/\*$/';
+    const REGEX_DESCENDANT_WILDCARD = '/\/\*$/';
 }

--- a/src/Config/Constants.php
+++ b/src/Config/Constants.php
@@ -69,7 +69,9 @@ class Constants
     const ROLE_CONFIGS_READ = 'api.configs_read';
     const ROLE_CONFIGS_EDIT = 'api.configs_edit';
 
-    // All available roles
+    /**
+     * All available API roles
+     */
     const ROLES = [
         Constants::ROLE_SUPER,
         Constants::ROLE_PAGES_READ,
@@ -88,4 +90,9 @@ class Constants
         Constants::ROLE_CONFIGS_READ,
         Constants::ROLE_CONFIGS_EDIT
     ];
+
+    /**
+     * Pattern for route matching which will allow "any descendents"
+     */
+    const REGEX_DESCENDENT_WILDCARD = '/\/\*$/';
 }

--- a/src/Config/Constants.php
+++ b/src/Config/Constants.php
@@ -57,6 +57,7 @@ class Constants
     const ROLE_PAGES_DELETE = 'api.pages_delete';
     const ROLE_PAGES_EDIT = 'api.pages_edit';
     const ROLE_PAGES_CREATE = 'api.pages_create';
+    const ROLE_PAGES_ADVANCED = 'api.pages_advanced_access';
     const ROLE_USERS_READ = 'api.users_read';
     const ROLE_USERS_DELETE = 'api.users_delete';
     const ROLE_USERS_CREATE = 'api.users_create';
@@ -75,6 +76,7 @@ class Constants
         Constants::ROLE_PAGES_DELETE,
         Constants::ROLE_PAGES_EDIT,
         Constants::ROLE_PAGES_CREATE,
+        Constants::ROLE_PAGES_ADVANCED,
         Constants::ROLE_USERS_READ,
         Constants::ROLE_USERS_DELETE,
         Constants::ROLE_USERS_CREATE,

--- a/src/Handlers/PagesHandler.php
+++ b/src/Handlers/PagesHandler.php
@@ -231,6 +231,24 @@ class PagesHandler extends BaseHandler
             return $response->withJson(Response::notFound(), 404);
         }
 
+        if (Config::instance()->pages->patch->useAuth) {
+
+            /** @var UserInterface */
+            $user = $request->getAttribute('user');
+
+            // Check if user has a role which allows any page access
+            $hasPermission = AuthHelper::checkRoles($user, [Constants::ROLE_PAGES_EDIT]);
+
+            if (!$hasPermission) {
+                // Check user's advanced API access permissions
+                $hasPageAccess = AuthHelper::hasPageAccess($user, $page, Constants::METHOD_PATCH);
+
+                if (!$hasPageAccess) {
+                    return $response->withJson(Response::unauthorized(), 401);
+                }
+            }
+        }
+
         $parsedBody = $request->getParsedBody();
 
         $template = isset($parsedBody['template'])

--- a/src/Helpers/ArrayHelper.php
+++ b/src/Helpers/ArrayHelper.php
@@ -34,6 +34,12 @@ class ArrayHelper
         return $current;
     }
 
+    /**
+     * Filters an array so it only contains values which are strings
+     *
+     * @param mixed[] $array
+     * @return string[]
+     */
     public static function asStringArray(array $array)
     {
         $filteredArray = [];
@@ -45,36 +51,5 @@ class ArrayHelper
         }
 
         return $filteredArray;
-    }
-
-    /**
-     * Intersects two arrays, returning an array containing only the shared items.
-     * Unlike `array_intersect`, it will work for values which are also arrays.
-     *
-     * @param array $a
-     * @param array $b
-     * @return array An empty array will be returned if there is no intersection.
-     */
-    public static function intersect($a, $b)
-    {
-        if (!is_array($a) || !is_array($b)) {
-            return array();
-        }
-
-        if (!empty($a)) {
-            foreach ($a as $key => $value) {
-                if (!isset($b[$key])) {
-                    unset($a[$key]);
-                } else {
-                    if (serialize($b[$key]) !== serialize($value)) {
-                        unset($a[$key]);
-                    }
-                }
-            }
-
-            return $a;
-        }
-
-        return array();
     }
 }

--- a/src/Helpers/ArrayHelper.php
+++ b/src/Helpers/ArrayHelper.php
@@ -46,4 +46,35 @@ class ArrayHelper
 
         return $filteredArray;
     }
+
+    /**
+     * Intersects two arrays, returning an array containing only the shared items.
+     * Unlike `array_intersect`, it will work for values which are also arrays.
+     *
+     * @param array $a
+     * @param array $b
+     * @return array An empty array will be returned if there is no intersection.
+     */
+    public static function intersect($a, $b)
+    {
+        if (!is_array($a) || !is_array($b)) {
+            return array();
+        }
+
+        if (!empty($a)) {
+            foreach ($a as $key => $value) {
+                if (!isset($b[$key])) {
+                    unset($a[$key]);
+                } else {
+                    if (serialize($b[$key]) !== serialize($value)) {
+                        unset($a[$key]);
+                    }
+                }
+            }
+
+            return $a;
+        }
+
+        return array();
+    }
 }

--- a/src/Helpers/AuthHelper.php
+++ b/src/Helpers/AuthHelper.php
@@ -82,7 +82,7 @@ class AuthHelper
         // Check user's routes against the page's route
         $hasMatchingRoute = self::hasMatchingRoute(
             $page->route(),
-            $user->get("api.advanced_access.pages.{$method}.routes", [])
+            self::getUserRoutes($user, $method)
         );
 
         if ($hasMatchingRoute) {
@@ -93,7 +93,7 @@ class AuthHelper
         // Check user against the page's taxonomies
         $hasTaxonomyIntersect = TaxonomyHelper::hasIntersect(
             $page->taxonomy(),
-            $user->get("api.advanced_access.pages.{$method}.taxonomy", [])
+            self::getUserTaxonomy($user, $method)
         );
 
         if ($hasTaxonomyIntersect) {
@@ -101,6 +101,30 @@ class AuthHelper
         }
 
         return false;
+    }
+
+    /**
+     * Returns an array of routes this user can access.
+     *
+     * @param UserInterface $user
+     * @param string $method
+     * @return string[] If no routes configured, an empty array will be returned.
+     */
+    public static function getUserRoutes($user, $method)
+    {
+        return $user->get("api.advanced_access.pages.{$method}.routes", []);
+    }
+
+    /**
+     * Returns an array of taxonomies this user can access.
+     *
+     * @param UserInterface $user
+     * @param string $method
+     * @return string[] If no taxonomies are configured, an empty array will be returned.
+     */
+    public static function getUserTaxonomy($user, $method)
+    {
+        return $user->get("api.advanced_access.pages.{$method}.taxonomy", []);
     }
 
     /**

--- a/src/Helpers/AuthHelper.php
+++ b/src/Helpers/AuthHelper.php
@@ -1,8 +1,12 @@
 <?php
 namespace GravApi\Helpers;
 
-use Grav\Common\User;
+use Grav\Common\Grav;
+use Grav\Common\Config\Config;
+use Grav\Common\User\Interfaces\UserInterface;
+use Grav\Common\Page\Interfaces\PageInterface;
 use GravApi\Config\Constants;
+use GravApi\Helpers\TaxonomyHelper;
 
 /**
  * Class AuthHelper
@@ -13,7 +17,7 @@ class AuthHelper
     /**
      * Checks whether a user has any of the required roles
      *
-     * @param User $user
+     * @param UserInterface $user
      * @param string[] $roles
      * @return bool
      */
@@ -28,6 +32,100 @@ class AuthHelper
 
         foreach ($allRoles as $role) {
             if ($user->authorize($role)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determines whether a user has access to a given page, based on the route or taxonomy values.
+     *
+     * @param UserInterface $user
+     * @param PageInterface $page
+     * @param string $method
+     * @return bool
+     */
+    public static function hasPageAccess($user, $page, $method)
+    {
+        /** @var Config */
+        $config = Grav::instance()['config'];
+        $groups = (array) $user->get('groups');
+
+        foreach ($groups as $group) {
+            // Check user's groups routes against page route
+            $routes = $config->get("groups.{$group}.api.advanced_access.pages.{$method}.routes", []);
+
+            $hasMatchingRoute = self::hasMatchingRoute(
+                $page->route(),
+                $routes
+            );
+
+            if ($hasMatchingRoute) {
+                return true;
+            }
+
+            // Check user's groups against the page's taxonomies
+            $taxonomies = $config->get("groups.{$group}.api.advanced_access.pages.{$method}.taxonomy", []);
+
+            $hasTaxonomyIntersect = TaxonomyHelper::hasIntersect(
+                $page->taxonomy(),
+                $taxonomies
+            );
+
+            if ($hasTaxonomyIntersect) {
+                return true;
+            }
+        }
+
+        // Check user's routes against the page's route
+        $hasMatchingRoute = self::hasMatchingRoute(
+            $page->route(),
+            $user->get("api.advanced_access.pages.{$method}.routes", [])
+        );
+
+        if ($hasMatchingRoute) {
+            return true;
+        }
+
+
+        // Check user against the page's taxonomies
+        $hasTaxonomyIntersect = TaxonomyHelper::hasIntersect(
+            $page->taxonomy(),
+            $user->get("api.advanced_access.pages.{$method}.taxonomy", [])
+        );
+
+        if ($hasTaxonomyIntersect) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Determines whether a page route matches a value from an array of routes.
+     *
+     * The array could include routes with the "any descendent" wildcard.
+     * For example, `/blog/*`, which would return true for a route such as `/blog/child`.
+     *
+     * @param string $route
+     * @param string[] $routes An array of accessible routes
+     * @return bool
+     */
+    public static function hasMatchingRoute($route, $routes)
+    {
+        foreach ($routes as $r) {
+            // Check the route for the "any descendent" wildcard
+            if (preg_match(Constants::REGEX_DESCENDENT_WILDCARD, $r)) {
+                // Replacing with a slash prevents matching on the exact $route, so we will only match descendents
+                $ancestor = preg_replace(Constants::REGEX_DESCENDENT_WILDCARD, '/', $r);
+
+                // Check if the route starts with the ancestor route
+                if (strpos($route, $ancestor) === 0) {
+                    return true;
+                }
+            } elseif ($route === $r) {
                 return true;
             }
         }

--- a/src/Helpers/AuthHelper.php
+++ b/src/Helpers/AuthHelper.php
@@ -1,0 +1,37 @@
+<?php
+namespace GravApi\Helpers;
+
+use Grav\Common\User;
+use GravApi\Config\Constants;
+
+/**
+ * Class AuthHelper
+ * @package GravApi\Helpers
+ */
+class AuthHelper
+{
+    /**
+     * Checks whether a user has any of the required roles
+     *
+     * @param User $user
+     * @param string[] $roles
+     * @return bool
+     */
+    public static function checkRoles($user, $roles)
+    {
+        if (!$user) {
+            return false;
+        }
+
+        // By default, the super role will always be allowed
+        $allRoles = array_merge([Constants::ROLE_SUPER], $roles);
+
+        foreach ($allRoles as $role) {
+            if ($user->authorize($role)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Helpers/AuthHelper.php
+++ b/src/Helpers/AuthHelper.php
@@ -112,7 +112,7 @@ class AuthHelper
             return array();
         }
 
-        return $user->get("api.advanced_access.pages.{$method}.routes", []);
+        return (array) $user->get("api.advanced_access.pages.{$method}.routes", []);
     }
 
     /**
@@ -128,7 +128,7 @@ class AuthHelper
             return array();
         }
 
-        return $user->get("api.advanced_access.pages.{$method}.taxonomy", []);
+        return (array) $user->get("api.advanced_access.pages.{$method}.taxonomy", []);
     }
 
     /**
@@ -143,7 +143,7 @@ class AuthHelper
         /** @var Config */
         $config = Grav::instance()['config'];
 
-        return $config->get("groups.{$group}.api.advanced_access.pages.{$method}.routes", []);
+        return (array) $config->get("groups.{$group}.api.advanced_access.pages.{$method}.routes", []);
     }
 
     /**
@@ -158,7 +158,7 @@ class AuthHelper
         /** @var Config */
         $config = Grav::instance()['config'];
 
-        return $config->get("groups.{$group}.api.advanced_access.pages.{$method}.taxonomy", []);
+        return (array) $config->get("groups.{$group}.api.advanced_access.pages.{$method}.taxonomy", []);
     }
 
     /**
@@ -171,7 +171,7 @@ class AuthHelper
      * @param string[] $routes An array of accessible routes
      * @return bool
      */
-    public static function hasMatchingRoute($route, $routes)
+    public static function hasMatchingRoute($route, array $routes)
     {
         foreach ($routes as $r) {
             // Check the route for the "any descendent" wildcard

--- a/src/Helpers/BlueprintHelper.php
+++ b/src/Helpers/BlueprintHelper.php
@@ -1,0 +1,38 @@
+<?php
+namespace GravApi\Helpers;
+
+use \Grav\Common\Grav;
+use \Grav\Common\Uri;
+use \Grav\Common\User\Interfaces\UserInterface;
+use \GravApi\Helpers\AuthHelper;
+
+/**
+ * Class BlueprintHelper
+ * @package GravApi\Helpers
+ */
+class BlueprintHelper
+{
+    /**
+     * Returns the API's advanced acess taxonomy field from the user's profile for a given HTTP method.
+     *
+     * This is a hacky workaround to populate the taxonomy field with data from the user's profile.
+     * See https://github.com/getgrav/grav-plugin-admin/issues/1472
+     *
+     * @param string $method One of `get`, `post`, `patch`, `delete`
+     * @return array An empty array will be return if no taxonomy data exists
+     */
+    public static function getUserTaxonomy($method)
+    {
+        $grav = Grav::instance();
+
+        /** @var Uri */
+        $uri = $grav['uri'];
+        // We extract the username from the URL, e.g. /admin/user/tom
+        $username = end($uri->paths());
+
+        /** @var UserInterface */
+        $user = $grav['accounts']->load($username);
+
+        return AuthHelper::getUserTaxonomy($user, $method);
+    }
+}

--- a/src/Helpers/TaxonomyHelper.php
+++ b/src/Helpers/TaxonomyHelper.php
@@ -1,11 +1,6 @@
 <?php
 namespace GravApi\Helpers;
 
-use \Grav\Common\Grav;
-use \Grav\Common\Uri;
-use \Grav\Common\User\Interfaces\UserInterface;
-use \GravApi\Helpers\AuthHelper;
-
 /**
  * Class TaxonomyHelper
  * @package GravApi\Helpers
@@ -66,29 +61,5 @@ class TaxonomyHelper
     public static function hasIntersect($a, $b)
     {
         return count(self::intersect($a, $b)) > 0;
-    }
-
-    /**
-     * Returns the API's advanced acess taxonomy field from the user's profile for a given HTTP method.
-     *
-     * This is a hacky workaround to populate the taxonomy field with data from the user's profile.
-     * See https://github.com/getgrav/grav-plugin-admin/issues/1472
-     *
-     * @param string $method One of `get`, `post`, `patch`, `delete`
-     * @return array An empty array will be return if no taxonomy data exists
-     */
-    public static function getUserTaxonomy($method)
-    {
-        $grav = Grav::instance();
-
-        /** @var Uri */
-        $uri = $grav['uri'];
-        // We extract the username from the URL, e.g. /admin/user/tom
-        $username = end($uri->paths());
-
-        /** @var UserInterface */
-        $user = $grav['accounts']->load($username);
-
-        return AuthHelper::getUserTaxonomy($user, $method);
     }
 }

--- a/src/Helpers/TaxonomyHelper.php
+++ b/src/Helpers/TaxonomyHelper.php
@@ -8,6 +8,24 @@ namespace GravApi\Helpers;
 class TaxonomyHelper
 {
     /**
+     * Merges two taxonomy arrays together, removing any duplicate values.
+     *
+     * @param array $a
+     * @param array $b
+     * @return array
+     */
+    public static function merge(array $a, array $b)
+    {
+        $result = array();
+
+        foreach (array_merge_recursive($a, $b) as $key => $value) {
+            $result[$key] = array_unique($value);
+        }
+
+        return $result;
+    }
+
+    /**
      * Intersects two taxonomy arrays, returning an array containing only the shared taxonomy values.
      *
      * @param array $a

--- a/src/Helpers/TaxonomyHelper.php
+++ b/src/Helpers/TaxonomyHelper.php
@@ -1,0 +1,47 @@
+<?php
+namespace GravApi\Helpers;
+
+/**
+ * Class TaxonomyHelper
+ * @package GravApi\Helpers
+ */
+class TaxonomyHelper
+{
+    /**
+     * Intersects two taxonomy arrays, returning an array containing only the shared taxonomy values.
+     *
+     * @param array $a
+     * @param array $b
+     * @return array An empty array will be returned if there is no intersection.
+     */
+    public static function intersect(array $a, array $b)
+    {
+        $result = array();
+
+        $matchingKeys = array_filter($a, function ($key) use ($b) {
+            return array_key_exists($key, $b);
+        }, ARRAY_FILTER_USE_KEY);
+
+
+        foreach ($matchingKeys as $key => $value) {
+            $intersect = array_intersect($value, $b[$key]);
+            if (count($intersect) > 0) {
+                $result[$key] = $intersect;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Determines if two taxonomy arrays share any values
+     *
+     * @param array $a
+     * @param array $b
+     * @return bool
+     */
+    public static function hasIntersect($a, $b)
+    {
+        return count(self::intersect($a, $b)) > 0;
+    }
+}

--- a/src/Helpers/TaxonomyHelper.php
+++ b/src/Helpers/TaxonomyHelper.php
@@ -4,6 +4,7 @@ namespace GravApi\Helpers;
 use \Grav\Common\Grav;
 use \Grav\Common\Uri;
 use \Grav\Common\User\Interfaces\UserInterface;
+use \GravApi\Helpers\AuthHelper;
 
 /**
  * Class TaxonomyHelper
@@ -88,6 +89,6 @@ class TaxonomyHelper
         /** @var UserInterface */
         $user = $grav['accounts']->load($username);
 
-        return $user->get("api.advanced_access.pages.{$method}.taxonomy", []);
+        return AuthHelper::getUserTaxonomy($user, $method);
     }
 }

--- a/src/Helpers/TaxonomyHelper.php
+++ b/src/Helpers/TaxonomyHelper.php
@@ -1,6 +1,10 @@
 <?php
 namespace GravApi\Helpers;
 
+use \Grav\Common\Grav;
+use \Grav\Common\Uri;
+use \Grav\Common\User\Interfaces\UserInterface;
+
 /**
  * Class TaxonomyHelper
  * @package GravApi\Helpers
@@ -61,5 +65,29 @@ class TaxonomyHelper
     public static function hasIntersect($a, $b)
     {
         return count(self::intersect($a, $b)) > 0;
+    }
+
+    /**
+     * Returns the API's advanced acess taxonomy field from the user's profile for a given HTTP method.
+     *
+     * This is a hacky workaround to populate the taxonomy field with data from the user's profile.
+     * See https://github.com/getgrav/grav-plugin-admin/issues/1472
+     *
+     * @param string $method One of `get`, `post`, `patch`, `delete`
+     * @return array An empty array will be return if no taxonomy data exists
+     */
+    public static function getUserTaxonomy($method)
+    {
+        $grav = Grav::instance();
+
+        /** @var Uri */
+        $uri = $grav['uri'];
+        // We extract the username from the URL, e.g. /admin/user/tom
+        $username = end($uri->paths());
+
+        /** @var UserInterface */
+        $user = $grav['accounts']->load($username);
+
+        return $user->get("api.advanced_access.pages.{$method}.taxonomy", []);
     }
 }

--- a/src/Helpers/TaxonomyHelper.php
+++ b/src/Helpers/TaxonomyHelper.php
@@ -19,7 +19,7 @@ class TaxonomyHelper
         $result = array();
 
         foreach (array_merge_recursive($a, $b) as $key => $value) {
-            $result[$key] = array_unique($value);
+            $result[$key] = array_values(array_unique($value));
         }
 
         return $result;

--- a/src/Middlewares/AuthMiddleware.php
+++ b/src/Middlewares/AuthMiddleware.php
@@ -5,6 +5,7 @@ use Grav\Common\Grav;
 use GravApi\Config\Method;
 use GravApi\Helpers\AuthHelper;
 use GravApi\Responses\Response;
+use Grav\Common\User\Interfaces\UserInterface;
 
 /**
  * Class AuthMiddleware
@@ -44,6 +45,8 @@ class AuthMiddleware
     {
         if ($this->config->useAuth) {
             // We try to get the user from the session
+
+            /** @var UserInterface */
             $sessionUser = $this->grav['session']->user;
 
             if ($sessionUser) {
@@ -60,6 +63,7 @@ class AuthMiddleware
                 $authUser = implode(' ', $request->getHeader('PHP_AUTH_USER')) ?: '';
                 $authPass = implode(' ', $request->getHeader('PHP_AUTH_PW')) ?: '';
 
+                /** @var UserInterface */
                 $user = $this->isAuthorised($authUser, $authPass);
 
                 if (!$user) {

--- a/src/Middlewares/AuthMiddleware.php
+++ b/src/Middlewares/AuthMiddleware.php
@@ -2,8 +2,8 @@
 namespace GravApi\Middlewares;
 
 use Grav\Common\Grav;
-use GravApi\Config\Constants;
 use GravApi\Config\Method;
+use GravApi\Helpers\AuthHelper;
 use GravApi\Responses\Response;
 
 /**
@@ -30,20 +30,15 @@ class AuthMiddleware
     {
         $this->config = $config;
         $this->grav = Grav::instance();
-
-        // These are default roles which allow for a user
-        // to use any part of the API
-        $defaultRoles = ['admin.super', Constants::ROLE_SUPER];
-
-        $this->roles = array_merge($defaultRoles, $roles);
+        $this->roles = $roles;
     }
 
     /**
-     * @param  \Psr\Http\Message\ServerRequestInterface $request  PSR7 request
-     * @param  \Psr\Http\Message\ResponseInterface      $response PSR7 response
-     * @param  callable                                 $next     Next middleware
+     * @param  \Slim\Http\Request $request  PSR7 request
+     * @param  \Slim\Http\Response $response PSR7 response
+     * @param  callable $next Next middleware
      *
-     * @return \Psr\Http\Message\ResponseInterface
+     * @return \Slim\Http\Response
      */
     public function __invoke($request, $response, $next)
     {
@@ -53,17 +48,27 @@ class AuthMiddleware
 
             if ($sessionUser) {
                 // Check if the session user has the required roles
-                if (!$this->checkRoles($sessionUser)) {
+                if (!AuthHelper::checkRoles($sessionUser, $this->roles)) {
                     return $response->withJson(Response::unauthorized(), 401);
                 }
+
+                // Authorisation has now passed for session auth,
+                // so we decorate the request with the user
+                $request = $request->withAttribute('user', $sessionUser);
             } else {
                 // Otherwise we check credentials from Basic auth
                 $authUser = implode(' ', $request->getHeader('PHP_AUTH_USER')) ?: '';
                 $authPass = implode(' ', $request->getHeader('PHP_AUTH_PW')) ?: '';
 
-                if (!$this->isAuthorised($authUser, $authPass)) {
+                $user = $this->isAuthorised($authUser, $authPass);
+
+                if (!$user) {
                     return $response->withJson(Response::unauthorized(), 401);
                 }
+
+                // Authorisation has now passed for Basic auth,
+                // so we decorate the request with the user
+                $request = $request->withAttribute('user', $user);
             }
         }
 
@@ -76,7 +81,7 @@ class AuthMiddleware
      * Authenticate against specified Grav user
      * @param  string $username
      * @param  string $password
-     * @return bool
+     * @return bool|User
      */
     public function isAuthorised($username, $password)
     {
@@ -86,26 +91,11 @@ class AuthMiddleware
         if ($isAuthenticated) {
             $user->authenticated = true;
 
-            if ($this->checkRoles($user)) {
-                return true;
+            if (AuthHelper::checkRoles($user, $this->roles)) {
+                return $user;
             }
         }
 
-        return false;
-    }
-
-    /**
-     * Checks if the user has any of the required roles
-     * @param  \Grav\Common\User\User $user
-     * @return bool
-     */
-    public function checkRoles($user)
-    {
-        foreach ($this->roles as $role) {
-            if ($user->authorize($role)) {
-                return true;
-            }
-        }
         return false;
     }
 }

--- a/tests/unit/Handlers/PagesHandlerTest.php
+++ b/tests/unit/Handlers/PagesHandlerTest.php
@@ -23,18 +23,19 @@ final class PagesHandlerTest extends Test
     /** @var PagesHandler $handler */
     protected $handler;
 
-    protected function _before($attributeFields = array())
+    protected function _before($attributes = array(), $endpoints = array())
     {
         $grav = Fixtures::get('grav');
         $this->grav = $grav();
 
-        Config::instance([
+        // initialise our default test config
+        $config = [
             'endpoints' => [
                 Constants::ENDPOINT_PAGE => [
                     Constants::METHOD_GET => [
                         'enabled' => true,
                         'auth' => false,
-                        'fields' => $attributeFields
+                        'fields' => $attributes
                     ],
                     Constants::METHOD_PATCH => [
                         'enabled' => true,
@@ -50,7 +51,14 @@ final class PagesHandlerTest extends Test
                     ]
                 ]
             ]
-        ]);
+        ];
+
+        // override our default config if custom endpoints are given
+        if (count($endpoints) > 0) {
+            $config['endpoints'] = $endpoints;
+        }
+
+        Config::instance($config);
 
         $this->handler = new PagesHandler();
         $this->response = new Response();
@@ -70,6 +78,99 @@ final class PagesHandlerTest extends Test
         $this->assertEquals(200, $response->getStatusCode());
     }
 
+    public function testGetPagesAuthShouldReturnStatus200(): void
+    {
+        $this->_before([], [
+            Constants::ENDPOINT_PAGE => [
+                Constants::METHOD_GET => [
+                    'enabled' => true,
+                    'auth' => true
+                ]
+            ]
+        ]);
+
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => '/api/pages'
+            ])
+        );
+
+        // Decorate the request with the user (which AuthMiddleware would usually do)
+        $user = $this->grav['accounts']->load('development');
+        $user->authenticated = true;
+        $request = $request->withAttribute('user', $user);
+
+        $response = $this->handler->getPages($request, $this->response, [
+            'page' => 'test'
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testGetPagesAdvancedAccessShouldReturnLimitedPages(): void
+    {
+        $this->_before([], [
+            Constants::ENDPOINT_PAGE => [
+                Constants::METHOD_GET => [
+                    'enabled' => true,
+                    'auth' => true
+                ]
+            ]
+        ]);
+
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => '/api/pages',
+            ])
+        );
+
+        // Decorate the request with the user (which AuthMiddleware would usually do)
+        $user = $this->grav['accounts']->load('greg');
+        $user->authenticated = true;
+        $request = $request->withAttribute('user', $user);
+
+        $response = $this->handler->getPages($request, $this->response, [
+            'page' => 'test'
+        ]);
+
+        $data = json_decode($response->getBody()->__toString());
+        $this->assertEquals(2, $data->meta->count);
+    }
+
+    public function testGetPagesAdvancedAccessShouldReturnEmptyArray(): void
+    {
+        $this->_before([], [
+            Constants::ENDPOINT_PAGE => [
+                Constants::METHOD_GET => [
+                    'enabled' => true,
+                    'auth' => true
+                ]
+            ]
+        ]);
+
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => '/api/pages',
+            ])
+        );
+
+        // Decorate the request with the user (which AuthMiddleware would usually do)
+        $user = $this->grav['accounts']->load('tom');
+        $user->authenticated = true;
+        $user->set('api.advanced_access.pages.get', []);
+        $request = $request->withAttribute('user', $user);
+
+        $response = $this->handler->getPages($request, $this->response, [
+            'page' => 'home'
+        ]);
+
+        $data = json_decode($response->getBody()->__toString());
+        $this->assertEquals(0, $data->meta->count);
+    }
+
     public function testGetPageShouldReturnStatus200(): void
     {
         $request = Request::createFromEnvironment(
@@ -84,6 +185,96 @@ final class PagesHandlerTest extends Test
         ]);
 
         $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testGetPageAuthShouldReturnStatus200(): void
+    {
+        $this->_before([], [
+            Constants::ENDPOINT_PAGE => [
+                Constants::METHOD_GET => [
+                    'enabled' => true,
+                    'auth' => true
+                ]
+            ]
+        ]);
+
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => '/api/pages/test'
+            ])
+        );
+
+        // Decorate the request with the user (which AuthMiddleware would usually do)
+        $user = $this->grav['accounts']->load('development');
+        $user->authenticated = true;
+        $request = $request->withAttribute('user', $user);
+
+        $response = $this->handler->getPage($request, $this->response, [
+            'page' => 'test'
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testGetPageAdvancedAccessShouldReturnStatus200(): void
+    {
+        $this->_before([], [
+            Constants::ENDPOINT_PAGE => [
+                Constants::METHOD_GET => [
+                    'enabled' => true,
+                    'auth' => true
+                ]
+            ]
+        ]);
+
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => '/api/pages/test',
+            ])
+        );
+
+        // Decorate the request with the user (which AuthMiddleware would usually do)
+        $user = $this->grav['accounts']->load('tom');
+        $user->authenticated = true;
+        $request = $request->withAttribute('user', $user);
+
+        $response = $this->handler->getPage($request, $this->response, [
+            'page' => 'test'
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testGetPageAdvancedAccessShouldReturnStatus401(): void
+    {
+        $this->_before([], [
+            Constants::ENDPOINT_PAGE => [
+                Constants::METHOD_GET => [
+                    'enabled' => true,
+                    'auth' => true
+                ]
+            ]
+        ]);
+
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => '/api/pages/home',
+            ])
+        );
+
+        // Decorate the request with the user (which AuthMiddleware would usually do)
+        $user = $this->grav['accounts']->load('tom');
+        $user->authenticated = true;
+        $request = $request->withAttribute('user', $user);
+
+        $response = $this->handler->getPage($request, $this->response, [
+            'page' => 'home'
+        ]);
+
+        $this->assertEquals(401, $response->getStatusCode());
     }
 
     public function testGetPageShouldReturnStatus404(): void
@@ -260,6 +451,107 @@ final class PagesHandlerTest extends Test
         $this->assertEquals('/test-order', $data->attributes->route);
     }
 
+    public function testNewPageAuthShouldReturnStatus200(): void
+    {
+        $this->_before([], [
+            Constants::ENDPOINT_PAGE => [
+                Constants::METHOD_POST => [
+                    'enabled' => true,
+                    'auth' => true
+                ]
+            ]
+        ]);
+
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'POST',
+                'REQUEST_URI' => '/api/pages'
+            ])
+        )->withParsedBody([
+            'route' => '/test-auth',
+            'header' => [
+                'title' => 'Test page'
+            ],
+            'order' => 1
+        ]);
+
+        // Decorate the request with the user (which AuthMiddleware would usually do)
+        $user = $this->grav['accounts']->load('development');
+        $user->authenticated = true;
+        $request = $request->withAttribute('user', $user);
+
+        $response = $this->handler->newPage($request, $this->response, []);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testNewPageAdvancedAccessShouldReturnStatus200(): void
+    {
+        $this->_before([], [
+            Constants::ENDPOINT_PAGE => [
+                Constants::METHOD_POST => [
+                    'enabled' => true,
+                    'auth' => true
+                ]
+            ]
+        ]);
+
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'POST',
+                'REQUEST_URI' => '/api/pages',
+            ])
+        )->withParsedBody([
+            'route' => '/test/advanced-auth',
+            'header' => [
+                'title' => 'Test page'
+            ]
+        ]);
+
+        // Decorate the request with the user (which AuthMiddleware would usually do)
+        $user = $this->grav['accounts']->load('tom');
+        $user->authenticated = true;
+        $request = $request->withAttribute('user', $user);
+
+        $response = $this->handler->newPage($request, $this->response, []);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testNewPageAdvancedAccessShouldReturnStatus401(): void
+    {
+        $this->_before([], [
+            Constants::ENDPOINT_PAGE => [
+                Constants::METHOD_POST => [
+                    'enabled' => true,
+                    'auth' => true
+                ]
+            ]
+        ]);
+
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'POST',
+                'REQUEST_URI' => '/api/pages',
+            ])
+        )->withParsedBody([
+            'route' => '/unauthorised-route',
+            'header' => [
+                'title' => 'Test page'
+            ],
+            'order' => 1
+        ]);
+
+        // Decorate the request with the user (which AuthMiddleware would usually do)
+        $user = $this->grav['accounts']->load('tom');
+        $user->authenticated = true;
+        $request = $request->withAttribute('user', $user);
+
+        $response = $this->handler->newPage($request, $this->response, []);
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
     public function testUpdatePageShouldReturnStatus400IfNoRouteGiven(): void
     {
         $request = Request::createFromEnvironment(
@@ -400,6 +692,118 @@ final class PagesHandlerTest extends Test
         $this->assertEquals('/test-order', $data->attributes->route);
     }
 
+    public function testUpdatePageAuthShouldReturnStatus200(): void
+    {
+        $this->_before([], [
+            Constants::ENDPOINT_PAGE => [
+                Constants::METHOD_PATCH => [
+                    'enabled' => true,
+                    'auth' => true
+                ]
+            ]
+        ]);
+
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'PATCH',
+                'REQUEST_URI' => '/api/pages'
+            ])
+        )->withParsedBody([
+            'route' => '/test-page',
+            'header' => [
+                'title' => 'Test page 2',
+                'taxonomy' => [
+                    'category' => [
+                        'blog'
+                    ]
+                ]
+            ],
+            'content' => 'This is some new authored content'
+        ]);
+
+        // Decorate the request with the user (which AuthMiddleware would usually do)
+        $user = $this->grav['accounts']->load('development');
+        $user->authenticated = true;
+        $request = $request->withAttribute('user', $user);
+
+        $response = $this->handler->getPage($request, $this->response, [
+            'page' => 'test-page'
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testUpdatePageAdvancedAccessShouldReturnStatus200(): void
+    {
+        $this->_before([], [
+            Constants::ENDPOINT_PAGE => [
+                Constants::METHOD_PATCH => [
+                    'enabled' => true,
+                    'auth' => true
+                ]
+            ]
+        ]);
+
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'PATCH',
+                'REQUEST_URI' => '/api/pages',
+            ])
+        )->withParsedBody([
+            'route' => '/test',
+            'header' => [
+                'title' => 'Test page'
+            ]
+        ]);
+
+        // Decorate the request with the user (which AuthMiddleware would usually do)
+        $user = $this->grav['accounts']->load('tom');
+        $user->authenticated = true;
+        $request = $request->withAttribute('user', $user);
+
+        $response = $this->handler->getPage($request, $this->response, [
+            'page' => 'test'
+        ]);
+
+        $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testUpdatePageAdvancedAccessShouldReturnStatus401(): void
+    {
+        $this->_before([], [
+            Constants::ENDPOINT_PAGE => [
+                Constants::METHOD_PATCH => [
+                    'enabled' => true,
+                    'auth' => true
+                ]
+            ]
+        ]);
+
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'PATCH',
+                'REQUEST_URI' => '/api/pages',
+            ])
+        )->withParsedBody([
+            'route' => '/home',
+            'header' => [
+                'title' => 'Change title',
+            ],
+            'content' => 'This is some failed content update'
+        ]);
+
+        // Decorate the request with the user (which AuthMiddleware would usually do)
+        $user = $this->grav['accounts']->load('tom');
+        $user->authenticated = true;
+        $request = $request->withAttribute('user', $user);
+
+        $response = $this->handler->getPage($request, $this->response, [
+            'page' => 'home'
+        ]);
+
+        $this->assertEquals(401, $response->getStatusCode());
+    }
+
     public function testDeletePageShouldReturnStatus404(): void
     {
         $request = Request::createFromEnvironment(
@@ -444,5 +848,101 @@ final class PagesHandlerTest extends Test
 
         $this->assertEquals(204, $responseTest->getStatusCode());
         $this->assertEquals(204, $responseOrder->getStatusCode());
+    }
+
+    public function testDeletePageAuthShouldReturnStatus204(): void
+    {
+        $this->_before([], [
+            Constants::ENDPOINT_PAGE => [
+                Constants::METHOD_DELETE => [
+                    'enabled' => true,
+                    'auth' => true
+                ]
+            ]
+        ]);
+
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'DELETE',
+                'REQUEST_URI' => '/api/pages/test-auth'
+            ])
+        );
+
+        // Decorate the request with the user (which AuthMiddleware would usually do)
+        $user = $this->grav['accounts']->load('development');
+        $user->authenticated = true;
+        $request = $request->withAttribute('user', $user);
+
+        $response = $this->handler->deletePage(
+            $request,
+            $this->response,
+            [ 'page' => 'test-auth' ]
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+    }
+
+    public function testDeletePageAdvancedAuthShouldReturnStatus204(): void
+    {
+        $this->_before([], [
+            Constants::ENDPOINT_PAGE => [
+                Constants::METHOD_DELETE => [
+                    'enabled' => true,
+                    'auth' => true
+                ]
+            ]
+        ]);
+
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'DELETE',
+                'REQUEST_URI' => '/api/pages/test/advanced-auth'
+            ])
+        );
+
+        // Decorate the request with the user (which AuthMiddleware would usually do)
+        $user = $this->grav['accounts']->load('tom');
+        $user->authenticated = true;
+        $request = $request->withAttribute('user', $user);
+
+        $response = $this->handler->deletePage(
+            $request,
+            $this->response,
+            [ 'page' => 'test/advanced-auth' ]
+        );
+
+        $this->assertEquals(204, $response->getStatusCode());
+    }
+
+    public function testDeletePageAdvancedAuthShouldReturnStatus401(): void
+    {
+        $this->_before([], [
+            Constants::ENDPOINT_PAGE => [
+                Constants::METHOD_DELETE => [
+                    'enabled' => true,
+                    'auth' => true
+                ]
+            ]
+        ]);
+
+        $request = Request::createFromEnvironment(
+            Environment::mock([
+                'REQUEST_METHOD' => 'DELETE',
+                'REQUEST_URI' => '/api/pages/home'
+            ])
+        );
+
+        // Decorate the request with the user (which AuthMiddleware would usually do)
+        $user = $this->grav['accounts']->load('tom');
+        $user->authenticated = true;
+        $request = $request->withAttribute('user', $user);
+
+        $response = $this->handler->deletePage(
+            $request,
+            $this->response,
+            [ 'page' => 'home' ]
+        );
+
+        $this->assertEquals(401, $response->getStatusCode());
     }
 }

--- a/tests/unit/Handlers/PagesHandlerTest.php
+++ b/tests/unit/Handlers/PagesHandlerTest.php
@@ -40,6 +40,10 @@ final class PagesHandlerTest extends Test
                         'enabled' => true,
                         'auth' => false
                     ],
+                    Constants::METHOD_POST => [
+                        'enabled' => true,
+                        'auth' => false
+                    ],
                     Constants::METHOD_DELETE => [
                         'enabled' => true,
                         'auth' => false

--- a/tests/unit/Handlers/PagesHandlerTest.php
+++ b/tests/unit/Handlers/PagesHandlerTest.php
@@ -33,7 +33,16 @@ final class PagesHandlerTest extends Test
                 Constants::ENDPOINT_PAGE => [
                     Constants::METHOD_GET => [
                         'enabled' => true,
+                        'auth' => false,
                         'fields' => $attributeFields
+                    ],
+                    Constants::METHOD_PATCH => [
+                        'enabled' => true,
+                        'auth' => false
+                    ],
+                    Constants::METHOD_DELETE => [
+                        'enabled' => true,
+                        'auth' => false
                     ]
                 ]
             ]
@@ -98,8 +107,8 @@ final class PagesHandlerTest extends Test
             ])
         )->withParsedBody([
             'taxonomyFilter' => [
-                'taxonomyKey1' => ['taxonomyValue1'],
-                'taxonomyKey2' => ['taxonomyValue2', 'taxonomyValue3']
+                'category' => ['blog'],
+                'tag' => ['news', 'grav']
             ],
             'operation' => 'and'
         ]);
@@ -118,7 +127,7 @@ final class PagesHandlerTest extends Test
             ])
         )->withParsedBody([
             'taxonomyFilter' => [
-                'taxonomyKey1' => ['taxonomyValue1']
+                'category' => ['blog']
             ],
             'operation' => 'and'
         ]);
@@ -137,7 +146,7 @@ final class PagesHandlerTest extends Test
             ])
         )->withParsedBody([
             'taxonomyFilter' => [
-                'taxonomyKey2' => ['taxonomyValue2']
+                'tag' => ['news']
             ],
             'operation' => 'or'
         ]);

--- a/tests/unit/Helpers/AuthHelperTest.php
+++ b/tests/unit/Helpers/AuthHelperTest.php
@@ -1,0 +1,505 @@
+<?php
+declare(strict_types=1);
+
+use Codeception\TestCase\Test;
+use Codeception\Util\Fixtures;
+use Grav\Common\Grav;
+use GravApi\Helpers\AuthHelper;
+
+final class AuthHelperTest extends Test
+{
+    /** @var Grav $client */
+    protected $grav;
+
+    protected function _before()
+    {
+        $grav = Fixtures::get('grav');
+        $this->grav = $grav();
+    }
+
+    public function testCheckRolesShouldReturnFalseWhenNullUserGiven(): void
+    {
+        $this->assertFalse(AuthHelper::checkRoles(null, []));
+    }
+
+    public function testCheckRolesShouldReturnFalseWhenUserLacksRole(): void
+    {
+        // Load user with no role
+        $user = $this->grav['accounts']->load('joe');
+        $user->authenticated = true;
+
+        $this->assertFalse(AuthHelper::checkRoles($user, ['api.pages_read']));
+    }
+
+    public function testCheckRolesShouldReturnTrueWhenUserHasSuperRole(): void
+    {
+        // Load user with no role
+        $user = $this->grav['accounts']->load('development');
+        $user->authenticated = true;
+
+        $this->assertTrue(AuthHelper::checkRoles($user, ['api.pages_read']));
+    }
+
+    public function testCheckRolesShouldReturnTrueWhenUserHasRole(): void
+    {
+        // Load user with no role
+        $user = $this->grav['accounts']->load('percy');
+        $user->authenticated = true;
+
+        $this->assertTrue(AuthHelper::checkRoles($user, ['api.pages_read']));
+    }
+
+    public function testHasPageAccessShouldReturnTrueWhenUserHasRoute(): void
+    {
+        // Load user with matching route
+        $user = $this->grav['accounts']->load('tom');
+        $user->set('api.advanced_access.pages.get', [
+            'routes' => [
+                '/test'
+            ]
+        ]);
+        $page = $this->grav['pages']->find('/test');
+
+        $this->assertTrue(AuthHelper::hasPageAccess($user, $page, 'get'));
+    }
+
+    public function testHasPageAccessShouldReturnTrueWhenUserHasTaxonomy(): void
+    {
+        // Load user with matching route
+        $user = $this->grav['accounts']->load('tom');
+        $user->set('api.advanced_access.pages.get', [
+            'taxonomy' => [
+                'category' => [
+                    'blog'
+                ]
+            ]
+        ]);
+        $page = $this->grav['pages']->find('/test');
+
+        $this->assertTrue(AuthHelper::hasPageAccess($user, $page, 'get'));
+    }
+
+    public function testHasPageAccessShouldReturnTrueWhenGroupHasRoute(): void
+    {
+        // Load user with matching route
+        $user = $this->grav['accounts']->load('tom');
+        $user->set('groups', ['testers']);
+        $page = $this->grav['pages']->find('/test');
+
+        $this->assertTrue(AuthHelper::hasPageAccess($user, $page, 'get'));
+    }
+
+    public function testHasPageAccessShouldReturnTrueWhenGroupHasTaxonomy(): void
+    {
+        // Load user with matching route
+        $user = $this->grav['accounts']->load('tom');
+        $user->set('groups', ['bloggers']);
+        $page = $this->grav['pages']->find('/test');
+
+        $this->assertTrue(AuthHelper::hasPageAccess($user, $page, 'get'));
+    }
+
+    public function testHasPageAccessShouldReturnFalseWhenNoPermissions(): void
+    {
+        // Load user with matching route
+        $user = $this->grav['accounts']->load('joe');
+        $page = $this->grav['pages']->find('/test');
+
+        $this->assertFalse(AuthHelper::hasPageAccess($user, $page, 'get'));
+    }
+
+    public function testGetUserRoutesShouldReturnArray(): void
+    {
+        // Load user with matching route
+        $user = $this->grav['accounts']->load('tom');
+        $user->set('api.advanced_access.pages.get', [
+            'routes' => '/test'
+        ]);
+
+        $this->assertIsArray(AuthHelper::getUserRoutes($user, 'get'));
+    }
+
+    public function testGetUserRoutesShouldReturnEmptyArray(): void
+    {
+        // Load user with matching route
+        $user = $this->grav['accounts']->load('tom');
+        $user->set('api.advanced_access.pages.get', []);
+
+        $this->assertEquals(0, count(AuthHelper::getUserRoutes($user, 'get')));
+        // For null user, we also expect an empty array
+        $this->assertEquals(0, count(AuthHelper::getUserRoutes(null, 'get')));
+    }
+
+    public function testGetUserRoutesShouldReturnUserData(): void
+    {
+        $data = ['/test'];
+
+        // Load user with matching route
+        $user = $this->grav['accounts']->load('tom');
+        $user->set('api.advanced_access.pages.get', [
+            'routes' => $data
+        ]);
+
+        $this->assertEquals($data, AuthHelper::getUserRoutes($user, 'get'));
+    }
+
+    public function testGetUserTaxonomyShouldReturnArray(): void
+    {
+        // Load user with matching route
+        $user = $this->grav['accounts']->load('tom');
+        $user->set('api.advanced_access.pages.get', [
+            'taxonomy' => [
+                'category' => [
+                    'blog'
+                ]
+            ]
+        ]);
+
+        $this->assertIsArray(AuthHelper::getUserTaxonomy($user, 'get'));
+    }
+
+    public function testGetUserTaxonomyShouldReturnEmptyArray(): void
+    {
+        // Load user with matching route
+        $user = $this->grav['accounts']->load('tom');
+        $user->set('api.advanced_access.pages.get', []);
+
+        $this->assertEquals(0, count(AuthHelper::getUserTaxonomy($user, 'get')));
+        // For null user, we also expect an empty array
+        $this->assertEquals(0, count(AuthHelper::getUserTaxonomy(null, 'get')));
+    }
+
+    public function testGetUserTaxonomyShouldReturnUserData(): void
+    {
+        $data = [
+            'category' => [
+                'blog'
+            ]
+        ];
+
+        // Load user with matching route
+        $user = $this->grav['accounts']->load('tom');
+        $user->set('api.advanced_access.pages.get', [
+            'taxonomy' => $data
+        ]);
+
+        $this->assertEquals($data, AuthHelper::getUserTaxonomy($user, 'get'));
+    }
+
+    public function testGetGroupRoutesShouldReturnArray(): void
+    {
+        $this->assertIsArray(AuthHelper::getGroupRoutes('testers', 'get'));
+    }
+
+    public function testGetGroupRoutesShouldReturnEmptyArray(): void
+    {
+        $this->assertEquals(0, count(AuthHelper::getGroupRoutes('siteadmin', 'get')));
+    }
+
+    public function testGetGroupRoutesShouldReturnUserData(): void
+    {
+        $data = ['/test'];
+
+        $this->assertEquals($data, AuthHelper::getGroupRoutes('testers', 'get'));
+    }
+
+    public function testGetGroupTaxonomyShouldReturnArray(): void
+    {
+        $this->assertIsArray(AuthHelper::getGroupTaxonomy('bloggers', 'get'));
+    }
+
+    public function testGetGroupTaxonomyShouldReturnEmptyArray(): void
+    {
+        $this->assertEquals(0, count(AuthHelper::getGroupTaxonomy('siteadmin', 'get')));
+    }
+
+    public function testGetGroupTaxonomyShouldReturnUserData(): void
+    {
+        $data = [
+            'category' => [
+                'blog'
+            ]
+        ];
+
+        $this->assertEquals($data, AuthHelper::getGroupTaxonomy('bloggers', 'get'));
+    }
+
+    public function testHasMatchingRouteShouldTrueForExactMatch(): void
+    {
+        $route = '/test';
+        $routes = ['/test'];
+
+        $this->assertTrue(AuthHelper::hasMatchingRoute($route, $routes));
+    }
+
+    public function testHasMatchingRouteShouldTrueForChild(): void
+    {
+        $route = '/test/child';
+        $routes = ['/test/*'];
+
+        $this->assertTrue(AuthHelper::hasMatchingRoute($route, $routes));
+    }
+
+    public function testHasMatchingRouteShouldTrueForDescendant(): void
+    {
+        $route = '/test/child/grandchild';
+        $routes = ['/test/*'];
+
+        $this->assertTrue(AuthHelper::hasMatchingRoute($route, $routes));
+    }
+
+    public function testHasMatchingRouteShouldFalseForParentOfDescendant(): void
+    {
+        $route = '/test';
+        $routes = ['/test/*'];
+
+        $this->assertFalse(AuthHelper::hasMatchingRoute($route, $routes));
+    }
+
+    public function testHasMatchingRouteShouldFalseForNoMatch(): void
+    {
+        $route = '/foo';
+        $routes = ['/bar'];
+
+        $this->assertFalse(AuthHelper::hasMatchingRoute($route, $routes));
+    }
+
+    public function testGetCollectionParamsShouldReturnPageSelfRoute(): void
+    {
+        $expect = ['@page.self' => '/test'];
+
+        // Load user with matching route
+        $user = $this->grav['accounts']->load('tom');
+        $user->set('api.advanced_access.pages.get', [
+            'routes' => ['/test']
+        ]);
+
+        $this->assertEquals($expect, AuthHelper::getCollectionParams($user));
+    }
+
+    public function testGetCollectionParamsShouldReturnPageDescendantRoute(): void
+    {
+        $expect = ['@page.descendants' => '/test'];
+
+        // Load user with matching route
+        $user = $this->grav['accounts']->load('tom');
+        $user->set('api.advanced_access.pages.get', [
+            'routes' => ['/test/*']
+        ]);
+
+        $this->assertEquals($expect, AuthHelper::getCollectionParams($user));
+    }
+
+    public function testGetCollectionParamsShouldRemoveDuplicateRoutes(): void
+    {
+        $expect = ['@page.self' => '/test'];
+
+        // Load user with matching route
+        $user = $this->grav['accounts']->load('tom');
+        $user->set('api.advanced_access.pages.get', [
+            'routes' => ['/test', '/test']
+        ]);
+
+        $this->assertEquals($expect, AuthHelper::getCollectionParams($user));
+    }
+
+    public function testGetCollectionParamsShouldKeepUniqueRoutes(): void
+    {
+        $expect = [
+            '@page.self' => '/test',
+            '@page.descendants' => '/test'
+        ];
+
+        // Load user with matching route
+        $user = $this->grav['accounts']->load('tom');
+        $user->set('api.advanced_access.pages.get', [
+            'routes' => ['/test', '/test/*']
+        ]);
+
+        $this->assertEquals($expect, AuthHelper::getCollectionParams($user));
+    }
+
+    public function testGetCollectionParamsShouldReturnTaxonomy(): void
+    {
+        $data = [
+            'category' => [
+                'blog'
+            ]
+        ];
+
+        $expect = [
+            '@taxonomy' => $data
+        ];
+
+        // Load user with matching route
+        $user = $this->grav['accounts']->load('tom');
+        $user->set('api.advanced_access.pages.get', [
+            'taxonomy' => $data
+        ]);
+
+        $this->assertEquals($expect, AuthHelper::getCollectionParams($user));
+    }
+
+    public function testGetCollectionParamsShouldReturnGroupRoutes(): void
+    {
+        $expect = ['@page.self' => '/test'];
+
+        // Load user with matching route
+        $user = $this->grav['accounts']->load('joe');
+        $user->set('groups', ['testers']);
+
+        $this->assertEquals($expect, AuthHelper::getCollectionParams($user));
+    }
+
+    public function testGetCollectionParamsShouldReturnGroupTaxonomy(): void
+    {
+        $data = [
+            'category' => [
+                'blog'
+            ]
+        ];
+
+        $expect = [
+            '@taxonomy' => $data
+        ];
+
+        // Load user with matching route
+        $user = $this->grav['accounts']->load('joe');
+        $user->set('groups', ['bloggers']);
+
+        $this->assertEquals($expect, AuthHelper::getCollectionParams($user));
+    }
+
+    public function testGetCollectionParamsShouldMergeGroupAndUserRoutes(): void
+    {
+        $expect = [
+            '@page.self' => '/test',
+            '@page.self' => '/typography'
+        ];
+
+        // Load user with matching route
+        $user = $this->grav['accounts']->load('tom');
+        $user->set('api.advanced_access.pages.get', [
+            'routes' => ['/typography']
+        ]);
+        $user->set('groups', ['testers']);
+
+        $this->assertEquals($expect, AuthHelper::getCollectionParams($user));
+    }
+
+    public function testGetCollectionParamsShouldRemoveGroupAndUserDuplicateRoutes(): void
+    {
+        $expect = [
+            '@page.self' => '/test'
+        ];
+
+        // Load user with matching route
+        $user = $this->grav['accounts']->load('tom');
+        $user->set('api.advanced_access.pages.get', [
+            'routes' => ['/test']
+        ]);
+        $user->set('groups', ['testers']);
+
+        $this->assertEquals($expect, AuthHelper::getCollectionParams($user));
+    }
+
+    public function testGetCollectionParamsShouldMergeGroupAndUserTaxonomy(): void
+    {
+        $taxonomy = [
+            'category' => [
+                'news'
+            ],
+            'tag' => [
+                'grav'
+            ]
+        ];
+
+        // We expect `category:news` and `tag:grav` from user and `category:blog` from group
+        $expect = [
+            '@taxonomy' => [
+                'category' => [
+                    'blog',
+                    'news'
+                ],
+                'tag' => [
+                    'grav'
+                ]
+            ]
+        ];
+
+        // Load user with matching route
+        $user = $this->grav['accounts']->load('tom');
+        $user->set('api.advanced_access.pages.get', [
+            'taxonomy' => $taxonomy
+        ]);
+        $user->set('groups', ['bloggers']);
+
+        $this->assertEquals($expect, AuthHelper::getCollectionParams($user));
+    }
+
+    public function testGetCollectionParamsShouldNotDuplicateGroupAndUserTaxonomy(): void
+    {
+        $taxonomy = [
+            'category' => [
+                'blog'
+            ]
+        ];
+
+        // We do not expect `category` or `blog` to appear twice, even though both user and group have it.
+        $expect = [
+            '@taxonomy' => [
+                'category' => [
+                    'blog'
+                ]
+            ]
+        ];
+
+        // Load user with matching route
+        $user = $this->grav['accounts']->load('tom');
+        $user->set('api.advanced_access.pages.get', [
+            'taxonomy' => $taxonomy
+        ]);
+        $user->set('groups', ['bloggers']);
+
+        $this->assertEquals($expect, AuthHelper::getCollectionParams($user));
+    }
+
+    public function testGetCollectionParamsShouldReturnAllFields(): void
+    {
+        $taxonomy = [
+            'category' => [
+                'blog',
+                'news'
+            ],
+            'tag' => [
+                'grav'
+            ]
+        ];
+
+        // We check that all routes and taxonomy values are added/deduplicated
+        $expect = [
+            '@page.self' => '/test',
+            '@page.self' => '/typography',
+            '@page.descendants' => '/test',
+            '@taxonomy' => [
+                'category' => [
+                    'blog',
+                    'news'
+                ],
+                'tag' => [
+                    'grav'
+                ]
+            ]
+        ];
+
+        // Load user with matching route
+        $user = $this->grav['accounts']->load('joe');
+        $user->set('api.advanced_access.pages.get', [
+            'routes' => ['/typography', '/test/*'],
+            'taxonomy' => $taxonomy
+        ]);
+        $user->set('groups', ['bloggers', 'testers']);
+
+        $this->assertEquals($expect, AuthHelper::getCollectionParams($user));
+    }
+}

--- a/tests/unit/Helpers/TaxonomyHelperTest.php
+++ b/tests/unit/Helpers/TaxonomyHelperTest.php
@@ -1,0 +1,187 @@
+<?php
+declare(strict_types=1);
+
+use Codeception\TestCase\Test;
+use GravApi\Helpers\TaxonomyHelper;
+
+final class TaxonomyHelperTest extends Test
+{
+    public function testMergeReturnsDistinctValues(): void
+    {
+        $a = [
+            'one' => [
+                'foo'
+            ]
+        ];
+
+        $b = [
+            'two' => [
+                'bar'
+            ]
+        ];
+
+        $expectedResult = [
+            'one' => ['foo'],
+            'two' => ['bar']
+        ];
+        $this->assertEquals(
+            $expectedResult,
+            TaxonomyHelper::merge($a, $b)
+        );
+    }
+
+    public function testMergeRemovesDuplicateValues(): void
+    {
+        $a = [
+            'one' => [
+                'foo'
+            ]
+        ];
+
+        $b = [
+            'one' => [
+                'foo'
+            ],
+            'two' => [
+                'bar'
+            ]
+        ];
+
+        $expectedResult = [
+            'one' => ['foo'],
+            'two' => ['bar']
+        ];
+        $this->assertEquals(
+            $expectedResult,
+            TaxonomyHelper::merge($a, $b)
+        );
+    }
+
+    public function testMergeAppendsNewValues(): void
+    {
+        $a = [
+            'one' => [
+                'boo'
+            ]
+        ];
+
+        $b = [
+            'one' => [
+                'foo'
+            ]
+        ];
+
+        $expectedResult = [
+            'one' => ['boo', 'foo'],
+        ];
+        $this->assertEquals(
+            $expectedResult,
+            TaxonomyHelper::merge($a, $b)
+        );
+    }
+
+    public function testIntersectRemovesUniqueKeys(): void
+    {
+        $a = [
+            'one' => [
+                'foo'
+            ]
+        ];
+
+        $b = [
+            'one' => [
+                'foo'
+            ],
+            'two' => [
+                'bar'
+            ]
+        ];
+
+        $expectedResult = [
+            'one' => ['foo']
+        ];
+        $this->assertEquals(
+            $expectedResult,
+            TaxonomyHelper::intersect($a, $b)
+        );
+    }
+
+    public function testIntersectRemovesRemovesUniqueValues(): void
+    {
+        $a = [
+            'one' => [
+                'foo'
+            ]
+        ];
+
+        $b = [
+            'one' => [
+                'foo',
+                'bar'
+            ]
+        ];
+
+        $expectedResult = [
+            'one' => ['foo']
+        ];
+        $this->assertEquals(
+            $expectedResult,
+            TaxonomyHelper::intersect($a, $b)
+        );
+    }
+
+    public function testIntersectReturnsEmptyArray(): void
+    {
+        $a = [
+            'one' => [
+                'foo'
+            ]
+        ];
+
+        $b = [
+            'one' => [
+                'bar'
+            ]
+        ];
+
+        $expectedResult = [];
+        $this->assertEquals(
+            $expectedResult,
+            TaxonomyHelper::intersect($a, $b)
+        );
+    }
+
+    public function testHasIntersectReturnsTrue(): void
+    {
+        $a = [
+            'one' => [
+                'foo'
+            ]
+        ];
+
+        $b = [
+            'one' => [
+                'foo'
+            ]
+        ];
+
+        $this->assertTrue(TaxonomyHelper::hasIntersect($a, $b));
+    }
+
+    public function testHasIntersectReturnsFalse(): void
+    {
+        $a = [
+            'one' => [
+                'foo'
+            ]
+        ];
+
+        $b = [
+            'one' => [
+                'bar'
+            ]
+        ];
+
+        $this->assertFalse(TaxonomyHelper::hasIntersect($a, $b));
+    }
+}

--- a/tests/unit/Resources/PageResourceTest.php
+++ b/tests/unit/Resources/PageResourceTest.php
@@ -86,7 +86,7 @@ final class PageResourceTest extends Test
             ],
             "filePathClean" => "user/pages/test/default.md",
             "folder" => "test",
-            "frontmatter" => "title: 'Test page'\ncustom_field: WORLD",
+            "frontmatter" => "title: 'Test page'\ncustom_field: WORLD\ntaxonomy:\n    category: blog\n    tag: [news, grav]\n",
             "header" => [
                 "title" => "Test page",
                 "custom_field" => "WORLD",
@@ -130,7 +130,7 @@ final class PageResourceTest extends Test
             "permalink" => "http://localhost/test",
             "publishDate" => null,
             "published" => true,
-            "raw" => "---\ntitle: 'Test page'\ncustom_field: WORLD\ntaxonomy:\n  category: blog\n  tag: [news, grav]\n---\n\n# Hello {{custom_field}}! This is a test.\n",
+            "raw" => "---\ntitle: 'Test page'\ncustom_field: WORLD\ntaxonomy:\n    category: blog\n    tag: [news, grav]\n---\n\n# Hello {{custom_field}}! This is a test.\n",
             "rawMarkdown" => "# Hello {{custom_field}}! This is a test.\n",
             "rawRoute" => "/test",
             "root" => false,

--- a/tests/unit/Resources/PageResourceTest.php
+++ b/tests/unit/Resources/PageResourceTest.php
@@ -91,10 +91,10 @@ final class PageResourceTest extends Test
                 "title" => "Test page",
                 "custom_field" => "WORLD",
                 "taxonomy" => [
-                    "taxonomyKey1" => "taxonomyValue1",
-                    "taxonomyKey2" => [
-                        "taxonomyValue2",
-                        "taxonomyValue3"
+                    "category" => "blog",
+                    "tag" => [
+                        "news",
+                        "grav"
                     ]
                 ]
             ],
@@ -130,7 +130,7 @@ final class PageResourceTest extends Test
             "permalink" => "http://localhost/test",
             "publishDate" => null,
             "published" => true,
-            "raw" => "---\ntitle: 'Test page'\ncustom_field: WORLD\ntaxonomy:\n  taxonomyKey1: taxonomyValue1\n  taxonomyKey2: [taxonomyValue2, taxonomyValue3]\n---\n\n# Hello {{custom_field}}! This is a test.\n",
+            "raw" => "---\ntitle: 'Test page'\ncustom_field: WORLD\ntaxonomy:\n  category: blog\n  tag: [news, grav]\n---\n\n# Hello {{custom_field}}! This is a test.\n",
             "rawMarkdown" => "# Hello {{custom_field}}! This is a test.\n",
             "rawRoute" => "/test",
             "root" => false,
@@ -140,12 +140,12 @@ final class PageResourceTest extends Test
             "slug" => "test",
             "summary" => "<h1>Hello {{custom_field}}! This is a test.</h1>",
             "taxonomy" => [
-                "taxonomyKey1" => [
-                    "taxonomyValue1"
+                "category" => [
+                    "blog"
                 ],
-                "taxonomyKey2" => [
-                    "taxonomyValue2",
-                    "taxonomyValue3"
+                "tag" => [
+                    "news",
+                    "grav"
                 ]
             ],
             "template" => "default",

--- a/tests/unit/Resources/UserResourceTest.php
+++ b/tests/unit/Resources/UserResourceTest.php
@@ -78,6 +78,9 @@ final class UserResourceTest extends Test
                 ],
                 'site' => [
                     'login' => true
+                ],
+                'api' => [
+                    'super' => true
                 ]
             ],
             'groups' => null
@@ -149,6 +152,9 @@ final class UserResourceTest extends Test
                 ],
                 'site' => [
                     'login' => true
+                ],
+                'api' => [
+                    'super' => true
                 ]
             ],
             'groups' => null
@@ -187,6 +193,9 @@ final class UserResourceTest extends Test
                 ],
                 'site' => [
                     'login' => true
+                ],
+                'api' => [
+                    'super' => true
                 ]
             ],
             'groups' => null


### PR DESCRIPTION
Closes #58 

Implements a more scalable and customisable authorisation of page resources as described in this comment: https://github.com/Regaez/grav-plugin-api/issues/58#issuecomment-611953547

### Tasks

- [x] Refactor `AuthMiddleware` to use new `AuthHelper` class
- [x] Create new `api.pages_advanced_access` role
- [x] Create new `TaxonomyHelper` class to determine shared taxonomy values
- [x] Enable advanced access for `getPage` handler
- [x] Enable advanced access for `updatePage` handler
- [x] Enable advanced access for `deletePage` handler
- [x] Enable advanced access for `getPages` handler
- [x] Enable advanced access for `createPage` handler
- [x] Create a blueprint to extend the `user/account` and add API advanced access form fields
- [x] Add tests for new functionality
