### PR TITLE
refactor: get username from admin->route

### DIFF
--- a/src/Helpers/BlueprintHelper.php
+++ b/src/Helpers/BlueprintHelper.php
@@ -2,7 +2,6 @@
 namespace GravApi\Helpers;
 
 use \Grav\Common\Grav;
-use \Grav\Common\Uri;
 use \Grav\Common\User\Interfaces\UserInterface;
 use \GravApi\Helpers\AuthHelper;
 
@@ -13,22 +12,20 @@ use \GravApi\Helpers\AuthHelper;
 class BlueprintHelper
 {
     /**
-     * Returns the API's advanced acess taxonomy field from the user's profile for a given HTTP method.
+     * Returns the API's advanced access taxonomy field from the user's profile for a given HTTP method.
      *
      * This is a hacky workaround to populate the taxonomy field with data from the user's profile.
      * See https://github.com/getgrav/grav-plugin-admin/issues/1472
      *
      * @param string $method One of `get`, `post`, `patch`, `delete`
-     * @return array An empty array will be return if no taxonomy data exists
+     * @return array An empty array will be returned if no taxonomy data exists
      */
     public static function getUserTaxonomy($method)
     {
         $grav = Grav::instance();
 
-        /** @var Uri */
-        $uri = $grav['uri'];
-        // We extract the username from the URL, e.g. /admin/user/tom
-        $username = end($uri->paths());
+        // We can pull the username from the admin route
+        $username = $grav['admin']->route;
 
         /** @var UserInterface */
         $user = $grav['accounts']->load($username);


### PR DESCRIPTION
Closes #90 

Use `$grav['admin']->route` instead of `Uri` class to more reliably get username of current edited user on admin page.